### PR TITLE
Native functions accept functions as parameters.

### DIFF
--- a/src/main/antlr/CoreDefinition.g4
+++ b/src/main/antlr/CoreDefinition.g4
@@ -28,10 +28,21 @@ attribute :
 
 method :
   DOC_COMMENT?
-  methodName=IDENTIFIER ('[' genericTypeList ']')? '(' parameterListDefinition ')' ':' methodType=IDENTIFIER;
+  methodName=IDENTIFIER ('[' genericTypeList ']')? '(' parameterListDefinition ')' ':' methodType=typeReference;
 
-parameterDefinition: parameterName=IDENTIFIER ':' parameterType=IDENTIFIER ('[' genericTypeList ']')?;
+parameterDefinition: parameterName=IDENTIFIER ':' abstractTypeReference;
 parameterListDefinition: ((parameterDefinition ',')* parameterDefinition | );
+
+typeReference: IDENTIFIER ('[' genericTypeList ']')?;
+typeReferenceList: (typeReference ',')* typeReference;
+lambdaReference
+  : input=typeReference '=>' output=typeReference
+  | '(' inputList=typeReferenceList ')' '=>' output=typeReference
+  ;
+abstractTypeReference
+  : typeReference
+  | lambdaReference
+  ;
 
 genericType: IDENTIFIER ('[' genericTypeList ']')?;
 genericTypeList: ((genericType ',')* genericType);

--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -23,8 +23,9 @@ chainedExpression : expression+;
 // Priority from top to bottom
 // The naming of all elements is to find the expression type
 expression
-  : '(' parenthesis=expression ')'
-  | methodExpression=expression '.' methodName=IDENTIFIER '(' methodExpressionParameters=expressionList? ')'
+  : '(' parameterListDefinition ')' '=>' '{' lambdaExpression=expression '}'
+  | '(' parenthesis=expression ')'
+  | methodExpression=expression '.' methodName=IDENTIFIER ('[' genericTypeList ']')? '(' methodExpressionParameters=expressionList? ')'
   | attributeExpression=expression '.' attributeName=IDENTIFIER
   | '!' notExpression=expression
   | leftExpression=expression operator=CALCULATOR_OPERATOR_LEVEL_1  rightExpression=expression

--- a/src/main/resources/api/List.definition
+++ b/src/main/resources/api/List.definition
@@ -6,4 +6,10 @@ type List[A] {
   head: A
 
   randomElement(): A
+
+  forall(f: A => Boolean): Boolean
+
+  exists(f: A => Boolean): Boolean
+
+  foldLeft[B](startValue: B, f: (B, A) => B): B
 }

--- a/src/main/resources/generators/scala/native/ListWrapper.scala
+++ b/src/main/resources/generators/scala/native/ListWrapper.scala
@@ -6,4 +6,10 @@ class ListWrapper[A](private val inner: List[A]) {
   def isEmpty(): Boolean = inner.isEmpty
 
   def head: A = inner.head
+
+  def forall(f: A => Boolean): Boolean = inner.forall(f)
+
+  def exists(f: A => Boolean): Boolean = inner.exists(f)
+
+  def foldLeft[B](startValue: B, f: (B, A) => B): B = inner.foldLeft(startValue)(f)
 }

--- a/src/main/resources/generators/ts/native/ListWrapper.ts
+++ b/src/main/resources/generators/ts/native/ListWrapper.ts
@@ -21,4 +21,20 @@ export class ListWrapper<A> {
         // Not really random, it is for the example currently.
         return this.inner ? this.inner[0] : null;
     }
+
+    forall(f: (A) => Boolean): Boolean {
+        return this.inner.every(f);
+    }
+
+    exists(f: (A) => Boolean): Boolean {
+        return this.inner.some(f);
+    }
+
+    foldLeft<B>(startValue: B, f: (B, A) => B): B {
+        let acc = startValue;
+        for (let i = 0 ; i < this.inner.length ; i++) {
+            acc = f(acc, this.inner[i]);
+        }
+        return acc;
+    }
 }

--- a/src/main/resources/samples/first.def
+++ b/src/main/resources/samples/first.def
@@ -76,3 +76,21 @@ type NonEmptyList[A] {
 }
 
 type NonEmptyPeriodList = NonEmptyList[Period]
+
+verification OnlyPositiveNumbers {
+  "Please provide only positive numbers"
+  (numberList: List[Number]) => {
+    numberList.forall((n: Number) => { n >= 0 })
+  }
+}
+
+type Balance {
+  entries: List[Number]
+
+  verify {
+    "The sum of entries must be 0"
+    (balance: Balance) => {
+      balance.entries.foldLeft[Number](0, (acc: Number, current: Number) => { acc + current }) > 0
+    }
+  }
+}

--- a/src/main/scala/definiti/AST.scala
+++ b/src/main/scala/definiti/AST.scala
@@ -1,7 +1,5 @@
 package definiti
 
-import spray.json.{JsObject, JsString, JsValue, JsonFormat}
-
 case class Position(line: Long, column: Long)
 
 case class Range(start: Position, end: Position)
@@ -11,11 +9,20 @@ case class Root(
   classDefinitions: Seq[ClassDefinition]
 )
 
+sealed trait AbstractTypeReference
+
 case class TypeReference(
   typeName: String,
   genericTypes: Seq[TypeReference]
-) {
+) extends AbstractTypeReference {
   def readableString: String = s"$typeName[${genericTypes.map(_.readableString).mkString(",")}]"
+}
+
+case class LambdaReference(
+  inputTypes: Seq[TypeReference],
+  outputType: TypeReference
+) extends AbstractTypeReference {
+  def readableString: String = s"(${inputTypes.map(_.readableString).mkString(", ")}) => ${outputType.readableString}"
 }
 
 case class AttributeDefinition(
@@ -28,8 +35,7 @@ case class AttributeDefinition(
 
 case class ParameterDefinition(
   name: String,
-  typeReference: TypeReference,
-  genericTypes: Seq[TypeReference],
+  typeReference: AbstractTypeReference,
   range: Range
 )
 
@@ -41,6 +47,9 @@ sealed trait ClassDefinition {
 
 sealed trait MethodDefinition {
   def name: String
+  def genericTypes: Seq[String]
+  def parameters: Seq[ParameterDefinition]
+  def comment: Option[String]
 }
 
 case class NativeClassDefinition(
@@ -115,7 +124,7 @@ case class QuotedStringValue(value: String, range: Range) extends Expression
 
 case class Variable(name: String, typeReference: TypeReference, range: Range) extends Expression
 
-case class MethodCall(expression: Expression, method: String, parameters: Seq[Expression], range: Range) extends Expression
+case class MethodCall(expression: Expression, method: String, parameters: Seq[Expression], generics: Seq[TypeReference], range: Range) extends Expression
 
 case class AttributeCall(expression: Expression, attribute: String, range: Range) extends Expression
 
@@ -125,6 +134,12 @@ case class Condition(
   condition: Expression,
   onTrue: Expression,
   onFalse: Option[Expression],
+  range: Range
+) extends Expression
+
+case class LambdaExpression(
+  parameterList: Seq[ParameterDefinition],
+  expression: Expression,
   range: Range
 ) extends Expression
 
@@ -145,92 +160,3 @@ case class DefinedType(name: String, genericTypes: Seq[String], attributes: Seq[
 case class AliasType(name: String, genericTypes: Seq[String], alias: TypeReference, inherited: Seq[String], comment: Option[String], range: Range) extends Type
 
 case class TypeVerification(message: String, function: DefinedFunction, range: Range)
-
-object ASTJsonProtocol {
-  import spray.json.DefaultJsonProtocol._
-
-  implicit val typeReferenceFormat: JsonFormat[TypeReference] = jsonFormat2(TypeReference.apply)
-  implicit val positionFormat: JsonFormat[Position] = jsonFormat2(Position.apply)
-  implicit val rangeFormat: JsonFormat[Range] = jsonFormat2(Range.apply)
-  implicit val orFormat: JsonFormat[Or] = jsonFormat3(Or.apply)
-  implicit val andFormat: JsonFormat[And] = jsonFormat3(And.apply)
-  implicit val equalFormat: JsonFormat[Equal] = jsonFormat3(Equal.apply)
-  implicit val notEqualFormat: JsonFormat[NotEqual] = jsonFormat3(NotEqual.apply)
-  implicit val lowerFormat: JsonFormat[Lower] = jsonFormat3(Lower.apply)
-  implicit val upperFormat: JsonFormat[Upper] = jsonFormat3(Upper.apply)
-  implicit val lowerOrEqualFormat: JsonFormat[LowerOrEqual] = jsonFormat3(LowerOrEqual.apply)
-  implicit val upperOrEqualFormat: JsonFormat[UpperOrEqual] = jsonFormat3(UpperOrEqual.apply)
-  implicit val plusFormat: JsonFormat[Plus] = jsonFormat3(Plus.apply)
-  implicit val minusFormat: JsonFormat[Minus] = jsonFormat3(Minus.apply)
-  implicit val moduloFormat: JsonFormat[Modulo] = jsonFormat3(Modulo.apply)
-  implicit val timeFormat: JsonFormat[Time] = jsonFormat3(Time.apply)
-  implicit val divideFormat: JsonFormat[Divide] = jsonFormat3(Divide.apply)
-  implicit val notFormat: JsonFormat[Not] = jsonFormat2(Not.apply)
-  implicit val booleanValueFormat: JsonFormat[BooleanValue] = jsonFormat2(BooleanValue.apply)
-  implicit val numberValueFormat: JsonFormat[NumberValue] = jsonFormat2(NumberValue.apply)
-  implicit val quotedStringValueFormat: JsonFormat[QuotedStringValue] = jsonFormat2(QuotedStringValue.apply)
-  implicit val variableFormat: JsonFormat[Variable] = jsonFormat(Variable.apply, "name", "typeReference", "range")
-  implicit val methodCallFormat: JsonFormat[MethodCall] = jsonFormat(MethodCall.apply, "expression", "method", "parameters", "range")
-  implicit val attributeCallFormat: JsonFormat[AttributeCall] = jsonFormat(AttributeCall.apply, "expression", "attribute", "range")
-  implicit val combinedExpressionFormat: JsonFormat[CombinedExpression] = jsonFormat(CombinedExpression.apply, "parts", "range")
-  implicit val conditionFormat: JsonFormat[Condition] = jsonFormat(Condition.apply, "condition", "onTrue", "onFalse", "range")
-
-  implicit def expressionFormat: JsonFormat[Expression] = new JsonFormat[Expression] {
-    def jsObject(typeName: String, content: JsValue): JsValue = {
-      JsObject(
-        "type" -> JsString(typeName),
-        "content" -> content
-      )
-    }
-
-    override def read(json: JsValue): Expression = ???
-
-    override def write(obj: Expression): JsValue = obj match {
-      case exp: BooleanValue => jsObject("BooleanValue", booleanValueFormat.write(exp))
-      case exp: NumberValue => jsObject("NumberValue", numberValueFormat.write(exp))
-      case exp: QuotedStringValue => jsObject("QuotedStringValue", quotedStringValueFormat.write(exp))
-      case exp: Variable => jsObject("Variable", variableFormat.write(exp))
-      case exp: MethodCall => jsObject("MethodCall", methodCallFormat.write(exp))
-      case exp: AttributeCall => jsObject("AttributeCall", attributeCallFormat.write(exp))
-      case exp: CombinedExpression => jsObject("CombinedExpression", combinedExpressionFormat.write(exp))
-      case exp: Condition => jsObject("Condition", conditionFormat.write(exp))
-      case exp: Or => jsObject("Or", orFormat.write(exp))
-      case exp: And => jsObject("And", andFormat.write(exp))
-      case exp: Equal => jsObject("Equal", equalFormat.write(exp))
-      case exp: NotEqual => jsObject("NotEqual", notEqualFormat.write(exp))
-      case exp: Lower => jsObject("Lower", lowerFormat.write(exp))
-      case exp: Upper => jsObject("Upper", upperFormat.write(exp))
-      case exp: LowerOrEqual => jsObject("LowerOrEqual", lowerOrEqualFormat.write(exp))
-      case exp: UpperOrEqual => jsObject("UpperOrEqual", upperOrEqualFormat.write(exp))
-      case exp: Plus => jsObject("Plus", plusFormat.write(exp))
-      case exp: Minus => jsObject("Minus", minusFormat.write(exp))
-      case exp: Modulo => jsObject("Modulo", moduloFormat.write(exp))
-      case exp: Time => jsObject("Time", timeFormat.write(exp))
-      case exp: Divide => jsObject("Divide", divideFormat.write(exp))
-      case exp: Not => jsObject("Not", notFormat.write(exp))
-    }
-  }
-
-  implicit val parameterDefinitionFormat: JsonFormat[ParameterDefinition] = jsonFormat(ParameterDefinition.apply, "name", "typeReference", "genericTypes", "range")
-  implicit val attributeDefinitionFormat: JsonFormat[AttributeDefinition] = jsonFormat(AttributeDefinition.apply, "name", "typeReference", "comment", "genericTypes", "range")
-  implicit val parameterFormat: JsonFormat[Parameter] = jsonFormat(Parameter.apply, "name", "typeReference", "range")
-  implicit val definedFunctionFormat: JsonFormat[DefinedFunction] = jsonFormat(DefinedFunction.apply, "parameters", "body", "genericTypes", "range")
-  implicit val verificationFormat: JsonFormat[Verification] = jsonFormat5(Verification.apply)
-  implicit val typeVerificationFormat: JsonFormat[TypeVerification] = jsonFormat3(TypeVerification.apply)
-  implicit val definedTypeFormat: JsonFormat[DefinedType] = jsonFormat(DefinedType.apply, "name", "genericTypes", "attributes", "verifications", "inherited", "comment", "range")
-  implicit val aliasTypeFormat: JsonFormat[AliasType] = jsonFormat(AliasType.apply, "name", "alias", "genericTypes", "inherited", "comment", "range")
-  implicit val nativeMethodDefinitionFormat: JsonFormat[NativeMethodDefinition] = jsonFormat(NativeMethodDefinition.apply, "name", "genericTypes", "parameters", "returnTypeReference", "comment")
-  implicit val nativeClassDefinitionFormat: JsonFormat[NativeClassDefinition] = jsonFormat(NativeClassDefinition.apply, "name", "genericTypes", "attributes", "methods", "comment")
-  implicit val definedMethodDefinitionFormat: JsonFormat[DefinedMethodDefinition] = jsonFormat(DefinedMethodDefinition.apply, "name", "genericTypes", "function", "comment", "range")
-
-  implicit val classDefinitionFormat: JsonFormat[ClassDefinition] = new JsonFormat[ClassDefinition] {
-    override def read(json: JsValue): ClassDefinition = ???
-
-    override def write(obj: ClassDefinition): JsValue = obj match {
-      case aliasType: AliasType => aliasTypeFormat.write(aliasType)
-      case definedType: DefinedType => definedTypeFormat.write(definedType)
-    }
-  }
-
-  implicit val rootFormat: JsonFormat[Root] = jsonFormat2(Root.apply)
-}

--- a/src/main/scala/definiti/api/Context.scala
+++ b/src/main/scala/definiti/api/Context.scala
@@ -1,6 +1,6 @@
 package definiti.api
 
-import definiti.{ClassDefinition, TypeReference, Verification}
+import definiti.{ClassDefinition, MethodDefinition, TypeReference, Verification}
 
 sealed trait Context {
   def isTypeAvailable(typeName: String): Boolean
@@ -45,6 +45,37 @@ case class ClassContext(
   override def findType(typeName: String): Option[ClassDefinition] = {
     if (currentType.genericTypes.contains(typeName)) {
       val indexOfGeneric = currentType.genericTypes.indexOf(typeName)
+      if (indexOfGeneric < genericTypes.size) {
+        outerContext.findType(genericTypes(indexOfGeneric).classDefinition.name)
+      } else {
+        None
+      }
+    } else {
+      outerContext.findType(typeName)
+    }
+  }
+
+  override def isVerificationAvailable(verificationName: String): Boolean = {
+    outerContext.isVerificationAvailable(verificationName)
+  }
+
+  override def findVerification(verificationName: String): Option[Verification] = {
+    outerContext.findVerification(verificationName)
+  }
+}
+
+case class MethodContext(
+  outerContext: Context,
+  currentMethod: MethodDefinition,
+  genericTypes: Seq[ClassReference]
+) extends Context {
+  override def isTypeAvailable(typeName: String): Boolean = {
+    currentMethod.genericTypes.contains(typeName) || outerContext.isTypeAvailable(typeName)
+  }
+
+  override def findType(typeName: String): Option[ClassDefinition] = {
+    if (currentMethod.genericTypes.contains(typeName)) {
+      val indexOfGeneric = currentMethod.genericTypes.indexOf(typeName)
       if (indexOfGeneric < genericTypes.size) {
         outerContext.findType(genericTypes(indexOfGeneric).classDefinition.name)
       } else {

--- a/src/main/scala/definiti/utils/ParserUtils.scala
+++ b/src/main/scala/definiti/utils/ParserUtils.scala
@@ -1,7 +1,8 @@
 package definiti.utils
 
-import definiti.{Position, Range}
+import definiti.{ParameterDefinition, Position, Range, TypeReference, Variable}
 import org.antlr.v4.runtime.ParserRuleContext
+import org.antlr.v4.runtime.tree.TerminalNode
 
 object ParserUtils {
   def extractStringContent(string: String): String = {
@@ -31,5 +32,21 @@ object ParserUtils {
       Position(context.getStart.getLine, context.getStart.getCharPositionInLine),
       Position(context.getStop.getLine, context.getStop.getCharPositionInLine)
     )
+  }
+
+  def getRangeFromTerminalNode(terminalNode: TerminalNode): Range = {
+    val symbol = terminalNode.getSymbol
+    Range(
+      Position(symbol.getLine, symbol.getStartIndex),
+      Position(symbol.getLine, symbol.getStopIndex)
+    )
+  }
+
+  def parametersToVariables(parameters: Seq[ParameterDefinition]) = {
+    def variableParameter(parameter: ParameterDefinition) = parameter.typeReference match {
+      case typeReference: TypeReference => typeReference
+      case x => throw new RuntimeException(s"The variable could not have $x as type reference")
+    }
+    parameters.map(parameter => Variable(parameter.name, variableParameter(parameter), parameter.range))
   }
 }

--- a/src/test/scala/definiti/api/ASTHelperSpec.scala
+++ b/src/test/scala/definiti/api/ASTHelperSpec.scala
@@ -176,6 +176,7 @@ class ASTHelperSpec extends FlatSpec with Matchers {
       expression = Variable("myString", TypeReference("String", Seq()), noRange),
       method = "nonEmpty",
       Seq(),
+      Seq(),
       range = noRange
     )
     val expected = Some(ClassReference(booleanDefinition, Seq()))
@@ -215,6 +216,7 @@ class ASTHelperSpec extends FlatSpec with Matchers {
       expression = Variable("myList", TypeReference("List", Seq(TypeReference("Number", Seq()))), noRange),
       method = "randomElement",
       parameters = Seq(),
+      generics = Seq(),
       range = noRange
     )
     val expected = Some(ClassReference(numberDefinition, Seq()))

--- a/src/test/scala/definiti/parser/ASTValidationSpec.scala
+++ b/src/test/scala/definiti/parser/ASTValidationSpec.scala
@@ -149,6 +149,7 @@ class ASTValidationSpec extends FlatSpec with Matchers {
         expression = Variable("myString", TypeReference("String", Seq()), noRange),
         method = "nonEmpty",
         Seq(),
+        Seq(),
         range = noRange
       )
     ) should ===(Valid)
@@ -178,6 +179,7 @@ class ASTValidationSpec extends FlatSpec with Matchers {
         expression = Variable("myList", TypeReference("List", Seq(TypeReference("Number", Seq()))), noRange),
         method = "nonEmpty",
         parameters = Seq(),
+        generics = Seq(),
         range = noRange
       )
     ) should ===(Valid)
@@ -212,6 +214,7 @@ class ASTValidationSpec extends FlatSpec with Matchers {
           expression = Variable("myList", TypeReference("List", Seq(TypeReference("Date", Seq()))), noRange),
           method = "randomElement",
           parameters = Seq(),
+          generics = Seq(),
           range = noRange
         ),
         attribute = "timestamp",


### PR DESCRIPTION
* Core types accept functions as parameters
* The developer can define lambda but they must provide all type information
* Inference should be done, but (deep?) refactoring is needed
* Update `List` from core to test new feature
* Update Wrappers for generators
* Update `first.def` to test new feature
* Generators acknowledge lambda
* `ASTHelper` consider now method definition and method call generics
* `Context` define a new `MethodContext` to consider the new context type
* `ASTValidation` also test lambda expressions
* Remove never-used JSON formats

This PR resolves #6 but type inference could be done in future release.