### PR TITLE
Create the module system

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ scalaVersion := "2.12.1"
 libraryDependencies += "io.spray" %%  "spray-json" % "1.3.3"
 libraryDependencies += "org.antlr" % "antlr4" % "4.7"
 
+// For developmen purposes
+libraryDependencies += "com.googlecode.kiama" %% "kiama" % "1.8.0"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-feature")

--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -10,7 +10,16 @@ LOGICAL_OPERATOR             : ('==' | '!=' | '<' | '<=' | '>' | '>=');
 LOGICAL_COMBINATION_OPERATOR : ('&&' | '||');
 NOT_OPERATOR                 : '!';
 
-definiti: toplevel*;
+definiti:
+  packageName?
+  imports*
+  toplevel*;
+
+packageName: 'package' dottedIdentifier;
+
+imports: 'import' dottedIdentifier;
+
+dottedIdentifier: (IDENTIFIER '.')* IDENTIFIER;
 
 toplevel
   : verification

--- a/src/main/resources/samples/src1/person.def
+++ b/src/main/resources/samples/src1/person.def
@@ -1,0 +1,11 @@
+package my.person
+
+import my.types.NonEmptyString
+import my.types.NonBlank
+import my.types.PhoneNumber
+
+type Person {
+  firstName: NonEmptyString
+  lastName: NonEmptyString
+  telephone: PhoneNumber
+}

--- a/src/main/resources/samples/src1/types.def
+++ b/src/main/resources/samples/src1/types.def
@@ -1,0 +1,45 @@
+package my.types
+
+type NonEmptyString {
+  content: String
+
+  verify {
+    "The string must not be empty"
+    (string: String) => {
+      string.nonEmpty()
+    }
+  }
+}
+
+type NonBlank {
+  content: String
+
+  verify {
+    "The string is blank /* quoted comment */"
+    (string: String) => {
+      string.trim().nonEmpty()
+    }
+  }
+}
+
+/**
+ * Could be simplified, but it is for the "example"
+ */
+type PhoneNumber {
+  content: String
+
+  verify {
+    "Please provide a phone number"
+    (string: String) => {
+      if (string.nonEmpty()) {
+        if (string.startsWith("+33")) {
+          string.matches("^\+33\d{9}$")
+        } else {
+          string.matches("^0\d{9}$")
+        }
+      } else {
+        false
+      }
+    }
+  }
+}

--- a/src/main/scala/definiti/core/Boot.scala
+++ b/src/main/scala/definiti/core/Boot.scala
@@ -1,11 +1,12 @@
 package definiti.core
 
 import java.nio.file.Paths
+import org.kiama.output.PrettyPrinter._
 
 object Boot extends App {
   try {
     val configuration = Configuration(
-      source = Paths.get("src", "main", "resources", "samples", "first.def"),
+      source = Paths.get("src", "main", "resources", "samples", "src1"),
       core = CoreConfiguration(
         source = Paths.get("src", "main", "resources", "api")
       )
@@ -17,7 +18,15 @@ object Boot extends App {
         errors.foreach(System.err.println)
       case Right(root) =>
         println("Done without error. Generated AST is:")
-        println(root)
+        val prettyRoot = root.copy(
+          files = List(root.files.map(rootFile => {
+            rootFile.copy(
+              verifications = List(rootFile.verifications: _*),
+              classDefinitions = List(rootFile.classDefinitions: _*)
+            )
+          }): _*)
+        )
+        println(pretty(any(prettyRoot)))
     }
   } catch {
     // In some cases, an Exception is thrown because the parser do not recognize an expression and crash its tree.

--- a/src/main/scala/definiti/core/Context.scala
+++ b/src/main/scala/definiti/core/Context.scala
@@ -15,19 +15,19 @@ case class ReferenceContext(
   verifications: Seq[Verification]
 ) extends Context {
   override def isTypeAvailable(typeName: String): Boolean = {
-    classes.exists(_.name == typeName)
+    classes.exists(_.canonicalName == typeName)
   }
 
   override def findType(typeName: String): Option[ClassDefinition] = {
-    classes.find(_.name == typeName)
+    classes.find(_.canonicalName == typeName)
   }
 
   override def isVerificationAvailable(verificationName: String): Boolean = {
-    verifications.exists(_.name == verificationName)
+    verifications.exists(_.canonicalName == verificationName)
   }
 
   override def findVerification(verificationName: String): Option[Verification] = {
-    verifications.find(_.name == verificationName)
+    verifications.find(_.canonicalName == verificationName)
   }
 }
 

--- a/src/main/scala/definiti/core/parser/ASTValidation.scala
+++ b/src/main/scala/definiti/core/parser/ASTValidation.scala
@@ -45,9 +45,9 @@ private[core] case class Error(message: String, range: Range) {
 
 private[core] object ASTValidation {
   def validate(root: Root)(implicit context: Context): Validation = {
-    val verificationValidations = root.verifications.map(validateVerification)
+    val verificationValidations = root.files.flatMap(_.verifications).map(validateVerification)
 
-    val classDefinitionValidations = root.classDefinitions.map {
+    val classDefinitionValidations = root.files.flatMap(_.classDefinitions).map {
       case aliasType: AliasType => validateAliasType(aliasType)
       case definedType: DefinedType => validateDefinedType(definedType)
       case _ => Valid

--- a/src/main/scala/definiti/core/parser/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/parser/ProjectLinking.scala
@@ -1,0 +1,166 @@
+package definiti.core.parser
+
+import definiti.core._
+import definiti.core.utils.StringUtils
+
+private[core] object ProjectLinking {
+  type TypeMapping = Map[String, String]
+  def emptyTypeMapping = Map.empty[String, String]
+
+  def injectLinks(projectParsingResult: ProjectParsingResult): ProjectParsingResult = {
+    val coreTypeMapping = extractTypeMappingFromCore(projectParsingResult.core)
+    projectParsingResult.copy(
+      root = injectLinksIntoRoot(projectParsingResult.root, coreTypeMapping)
+    )
+  }
+
+  private def extractTypeMappingFromCore(core: Seq[ClassDefinition]): TypeMapping = {
+    core
+      .view
+      .map(_.name)
+      .map(name => StringUtils.lastPart(name, '.') -> name)
+      .toMap
+  }
+
+  private def injectLinksIntoRoot(root: Root, coreTypeMapping: TypeMapping): Root = {
+    root.copy(
+      root.files.map(injectLinksIntoRootFile(_, coreTypeMapping))
+    )
+  }
+
+  private def injectLinksIntoRootFile(rootFile: RootFile, coreTypeMapping: TypeMapping): RootFile = {
+    val fileTypeMapping = extractTypeMappingFromFile(rootFile)
+    val imports = rootFile.imports
+    val typeMapping = coreTypeMapping ++ fileTypeMapping ++ imports
+    rootFile.copy(
+      verifications = rootFile.verifications.map(injectLinksIntoVerification(_, rootFile.packageName, typeMapping)),
+      classDefinitions = rootFile.classDefinitions.map(injectLinksIntoClassDefinition(_, rootFile.packageName, typeMapping))
+    )
+  }
+
+  private def extractTypeMappingFromFile(rootFile: RootFile): TypeMapping = {
+    val verificationTypeMapping = rootFile.verifications
+      .view
+      .map(_.name)
+      .map(name => name -> (rootFile.packageName + "." + name))
+      .toMap
+    val classDefinitionTypeMapping = rootFile.classDefinitions
+      .view
+      .map(_.name)
+      .map(name => name -> (rootFile.packageName + "." + name))
+      .toMap
+
+    verificationTypeMapping ++ classDefinitionTypeMapping
+  }
+
+  private def injectLinksIntoVerification(verification: Verification, packageName: String, typeMapping: TypeMapping): Verification = {
+    verification.copy(
+      packageName = packageName,
+      function = injectLinksIntoFunction(verification.function, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoClassDefinition(classDefinition: ClassDefinition, packageName: String, typeMapping: TypeMapping): ClassDefinition = {
+    classDefinition match {
+      case aliasType: AliasType =>
+        aliasType.copy(
+          packageName = packageName,
+          alias = injectLinksIntoTypeReference(aliasType.alias, typeMapping),
+          inherited = aliasType.inherited.map(getLink(_, typeMapping))
+        )
+      case definedType: DefinedType =>
+        definedType.copy(
+          packageName = packageName,
+          attributes = definedType.attributes.map(injectLinksIntoAttributes(_, typeMapping)),
+          verifications = definedType.verifications.map(injectLinksIntoTypeVerification(_, typeMapping)),
+          inherited = definedType.inherited.map(getLink(_, typeMapping))
+        )
+      case other => other
+    }
+  }
+
+  private def injectLinksIntoAttributes(attributeDefinition: AttributeDefinition, typeMapping: TypeMapping): AttributeDefinition = {
+    attributeDefinition.copy(
+      typeReference = injectLinksIntoTypeReference(attributeDefinition.typeReference, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoTypeVerification(typeVerification: TypeVerification, typeMapping: TypeMapping): TypeVerification = {
+    typeVerification.copy(
+      function = injectLinksIntoFunction(typeVerification.function, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoFunction(function: DefinedFunction, typeMapping: TypeMapping): DefinedFunction = {
+    function.copy(
+      parameters = function.parameters.map(injectLinksIntoParameter(_, typeMapping)),
+      body = injectLinksIntoExpression(function.body, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoParameter(parameterDefinition: ParameterDefinition, typeMapping: TypeMapping): ParameterDefinition = {
+    parameterDefinition.copy(
+      typeReference = injectLinksIntoAbstractTypeReference(parameterDefinition.typeReference, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoAbstractTypeReference(abstractTypeReference: AbstractTypeReference, typeMapping: TypeMapping): AbstractTypeReference = {
+    abstractTypeReference match {
+      case typeReference: TypeReference => injectLinksIntoTypeReference(typeReference, typeMapping)
+      case lambdaReference: LambdaReference => injectLinksIntoLambdaReference(lambdaReference, typeMapping)
+    }
+  }
+
+  private def injectLinksIntoTypeReference(typeReference: TypeReference, typeMapping: TypeMapping): TypeReference = {
+    typeReference.copy(
+      typeName = getLink(typeReference.typeName, typeMapping),
+      genericTypes = typeReference.genericTypes.map(injectLinksIntoTypeReference(_, typeMapping))
+    )
+  }
+
+  private def injectLinksIntoLambdaReference(lambdaReference: LambdaReference, typeMapping: TypeMapping): LambdaReference = {
+    lambdaReference.copy(
+      inputTypes = lambdaReference.inputTypes.map(injectLinksIntoTypeReference(_, typeMapping)),
+      outputType = injectLinksIntoTypeReference(lambdaReference.outputType, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoExpression(expression: Expression, typeMapping: TypeMapping): Expression = {
+    expression match {
+      case logicalExpression: LogicalExpression => logicalExpression
+      case calculatorExpression: CalculatorExpression => calculatorExpression
+      case numberValue: NumberValue => numberValue
+      case quotedStringValue: QuotedStringValue => quotedStringValue
+      case variable: Variable => variable
+      case methodCall: MethodCall =>
+        methodCall.copy(
+          expression = injectLinksIntoExpression(methodCall.expression, typeMapping),
+          parameters = methodCall.parameters.map(injectLinksIntoExpression(_, typeMapping)),
+          generics = methodCall.generics.map(injectLinksIntoTypeReference(_, typeMapping))
+        )
+      case attributeCall: AttributeCall =>
+        attributeCall.copy(
+          expression = injectLinksIntoExpression(attributeCall.expression, typeMapping)
+        )
+      case combinedExpression: CombinedExpression =>
+        combinedExpression.copy(
+          parts = combinedExpression.parts.map(injectLinksIntoExpression(_, typeMapping))
+        )
+      case condition: Condition =>
+        condition.copy(
+          condition = injectLinksIntoExpression(condition.condition, typeMapping),
+          onTrue = injectLinksIntoExpression(condition.onTrue, typeMapping),
+          onFalse = condition.onFalse.map(injectLinksIntoExpression(_, typeMapping))
+        )
+      case lambdaExpression: LambdaExpression =>
+        lambdaExpression.copy(
+          expression = injectLinksIntoExpression(lambdaExpression.expression, typeMapping),
+          parameterList = lambdaExpression.parameterList.map(injectLinksIntoParameter(_, typeMapping))
+        )
+    }
+  }
+
+  private def getLink(name: String, typeMapping: TypeMapping): String = {
+    typeMapping.getOrElse(name, name)
+  }
+}

--- a/src/main/scala/definiti/core/parser/ProjectParser.scala
+++ b/src/main/scala/definiti/core/parser/ProjectParser.scala
@@ -4,7 +4,7 @@ import java.nio.file.{Files, Path}
 
 import definiti.core.parser.antlr.{CoreDefinitionLexer, CoreDefinitionParser, DefinitiLexer, DefinitiParser}
 import definiti.core.utils.{ErrorItem, ErrorListener}
-import definiti.core.{ClassDefinition, Configuration, Root}
+import definiti.core.{ClassDefinition, Configuration, Root, RootFile}
 import org.antlr.v4.runtime._
 import definiti.core.utils.CollectionUtils._
 
@@ -24,10 +24,24 @@ private[core] class ProjectParser(configuration: Configuration) {
   }
 
   private def buildDefinitiAST(): Either[Seq[ErrorItem], Root] = {
-    parseDefinitiFile(configuration.source.toString)
+    val sourceFiles = extractDefinitiFiles()
+    val definitiAstEither = sourceFiles.map(path => parseDefinitiFile(path.toString))
+    if (definitiAstEither.forall(_.isRight)) {
+      val allAST = definitiAstEither.map(_.right.get)
+      Right(Root(allAST))
+    } else {
+      val allErrors = definitiAstEither.collect {
+        case Left(errors) => errors
+      }.flatten
+      Left(allErrors)
+    }
   }
 
-  private def parseDefinitiFile(source: String): Either[Seq[ErrorItem], Root] = {
+  private def extractDefinitiFiles(): Seq[Path] = {
+    scalaSeq(Files.find(configuration.source, 1000, (path, _) => String.valueOf(path).endsWith(".def")))
+  }
+
+  private def parseDefinitiFile(source: String): Either[Seq[ErrorItem], RootFile] = {
     val errorListener = new ErrorListener(source)
     val parser = buildParser(source, new DefinitiLexer(_), new DefinitiParser(_), errorListener)
     val result: DefinitiParser.DefinitiContext = parser.definiti()

--- a/src/main/scala/definiti/core/parser/package.scala
+++ b/src/main/scala/definiti/core/parser/package.scala
@@ -1,0 +1,9 @@
+package definiti.core
+
+package object parser {
+  type ImportsMap = Map[String, String]
+
+  val emptyImportsMap: ImportsMap = Map.empty[String, String]
+
+  val NOT_DEFINED: String = "NOT_DEFINED"
+}

--- a/src/main/scala/definiti/core/utils/StringUtils.scala
+++ b/src/main/scala/definiti/core/utils/StringUtils.scala
@@ -1,0 +1,13 @@
+package definiti.core.utils
+
+object StringUtils {
+  def lastPart(source: String, separator: Char): String = {
+    if (source.last == separator) {
+      lastPart(source.substring(0, source.length - 1), separator)
+    } else if (source.contains(separator)) {
+      source.substring(source.lastIndexOf(".") + 1)
+    } else {
+      source
+    }
+  }
+}


### PR DESCRIPTION
* Update the *antlr* definition to include `package` and `import` syntax
* Create a directory containing a project test
* The AST is divided into several `RootFiles` instead of a unique `Root` (`Root` contains `RootFiles`)
* Define a canonical name being the element (type, verification) name with its package name
* Consider this model transformation into AST building
* Consider this model transformation into AST validation
* The link between elements of the project is done into `ProjectLinking`
* This PR resolves #7