### PR TITLE
Attributes can have verification directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies += "org.antlr" % "antlr4" % "4.7"
 libraryDependencies += "com.googlecode.kiama" %% "kiama" % "1.8.0"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-feature")
 

--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -67,7 +67,9 @@ definedType :
 
 attributeDefinition:
   DOC_COMMENT?
-  attributeName=IDENTIFIER ':' attributeType=IDENTIFIER ('[' genericTypeList ']')?;
+  attributeName=IDENTIFIER ':' attributeType=IDENTIFIER ('[' genericTypeList ']')? attributeVerifications;
+
+attributeVerifications: ('verifying' IDENTIFIER)*;
 
 typeVerification:
   'verify' '{'

--- a/src/main/resources/samples/src2/person.def
+++ b/src/main/resources/samples/src2/person.def
@@ -1,0 +1,11 @@
+package my.person
+
+import my.verifications.NonEmptyString
+import my.verifications.NonBlank
+import my.verifications.PhoneNumber
+
+type Person {
+  firstName: String verifying NonEmptyString
+  lastName: String verifying NonEmptyString
+  telephone: String verifying NonBlank verifying PhoneNumber
+}

--- a/src/main/resources/samples/src2/verifications.def
+++ b/src/main/resources/samples/src2/verifications.def
@@ -1,0 +1,30 @@
+package my.verifications
+
+verification NonEmptyString {
+  "The string must not be empty"
+  (string: String) => {
+    string.nonEmpty()
+  }
+}
+
+verification NonBlank {
+  "The string is blank /* quoted comment */"
+  (string: String) => {
+    string.trim().nonEmpty()
+  }
+}
+
+verification PhoneNumber {
+  "Please provide a phone number"
+  (string: String) => {
+    if (string.nonEmpty()) {
+      if (string.startsWith("+33")) {
+        string.matches("^\+33\d{9}$")
+      } else {
+        string.matches("^0\d{9}$")
+      }
+    } else {
+      false
+    }
+  }
+}

--- a/src/main/scala/definiti/core/AST.scala
+++ b/src/main/scala/definiti/core/AST.scala
@@ -46,6 +46,7 @@ case class AttributeDefinition(
   typeReference: TypeReference,
   comment: Option[String],
   genericTypes: Seq[TypeReference],
+  verifications: Seq[String],
   range: Range
 )
 

--- a/src/main/scala/definiti/core/AST.scala
+++ b/src/main/scala/definiti/core/AST.scala
@@ -45,7 +45,6 @@ case class AttributeDefinition(
   name: String,
   typeReference: TypeReference,
   comment: Option[String],
-  genericTypes: Seq[TypeReference],
   verifications: Seq[String],
   range: Range
 )

--- a/src/main/scala/definiti/core/Boot.scala
+++ b/src/main/scala/definiti/core/Boot.scala
@@ -6,7 +6,7 @@ import org.kiama.output.PrettyPrinter._
 object Boot extends App {
   try {
     val configuration = Configuration(
-      source = Paths.get("src", "main", "resources", "samples", "src1"),
+      source = Paths.get("src", "main", "resources", "samples", "src2"),
       core = CoreConfiguration(
         source = Paths.get("src", "main", "resources", "api")
       )

--- a/src/main/scala/definiti/core/parser/ASTValidation.scala
+++ b/src/main/scala/definiti/core/parser/ASTValidation.scala
@@ -56,7 +56,7 @@ private[core] object ASTValidation {
     Validation.join(verificationValidations ++ classDefinitionValidations)
   }
 
-  private def validateVerification(verification: Verification)(implicit context: Context) = {
+  def validateVerification(verification: Verification)(implicit context: Context): Validation = {
     validateExpression(verification.function.body).verifyingAlso {
       val functionReturnType = ASTHelper.getReturnTypeOfExpression(verification.function.body)
       if (functionReturnType.classDefinition.name == "Boolean") {
@@ -67,7 +67,7 @@ private[core] object ASTValidation {
     }
   }
 
-  private def validateAliasType(aliasType: AliasType)(implicit context: Context): Validation = {
+  def validateAliasType(aliasType: AliasType)(implicit context: Context): Validation = {
     verifyTypeReference(aliasType).verifyingAlso {
       Validation.join(aliasType.inherited.map { verification =>
         context.findVerification(verification) match {
@@ -101,7 +101,7 @@ private[core] object ASTValidation {
     Validation.join(inheritedValidations ++ attributeValidations ++ verificationValidations)
   }
 
-  private def validateAttributeDefinition(attribute: AttributeDefinition)(implicit context: Context): Validation = {
+  def validateAttributeDefinition(attribute: AttributeDefinition)(implicit context: Context): Validation = {
     val typeReferenceValidation = context.findType(attribute.typeReference.typeName) match {
       case Some(_) => Valid
       case None => Invalid("Undefined type: " + attribute.typeReference, attribute.range)
@@ -187,7 +187,7 @@ private[core] object ASTValidation {
       }
   }
 
-  private def validateMethodCall(methodCall: MethodCall)(implicit context: Context) = {
+  def validateMethodCall(methodCall: MethodCall)(implicit context: Context): Validation = {
     validateExpression(methodCall.expression).verifyingAlso {
       val innerReturnType = ASTHelper.getReturnTypeOfExpression(methodCall.expression)
       ASTHelper.getMethodOpt(innerReturnType.classDefinition, methodCall.method) match {
@@ -213,7 +213,7 @@ private[core] object ASTValidation {
     }
   }
 
-  private def validateReturnTypeExpression(expression: Expression, expectedReturnType: AbstractTypeReference, classDefinition: ClassDefinition, methodDefinition: MethodDefinition)(implicit context: Context): Validation = {
+  def validateReturnTypeExpression(expression: Expression, expectedReturnType: AbstractTypeReference, classDefinition: ClassDefinition, methodDefinition: MethodDefinition)(implicit context: Context): Validation = {
     val expressionReturnTypeOpt = ASTHelper.getReturnTypeOptOfExpression(expression)
     expressionReturnTypeOpt.map { expressionReturnType =>
       expectedReturnType match {
@@ -229,7 +229,7 @@ private[core] object ASTValidation {
     } getOrElse Invalid("Can not determine return type of expression", expression.range)
   }
 
-  private def validateLambdaExpressionAndReference(lambdaExpression: LambdaExpression, lambdaReference: LambdaReference, classDefinition: ClassDefinition, methodDefinition: MethodDefinition)(implicit context: Context): Validation = {
+  def validateLambdaExpressionAndReference(lambdaExpression: LambdaExpression, lambdaReference: LambdaReference, classDefinition: ClassDefinition, methodDefinition: MethodDefinition)(implicit context: Context): Validation = {
     val expressionParameters = lambdaExpression.parameterList
     val referenceParameters = lambdaReference.inputTypes
     if (expressionParameters.length == referenceParameters.length) {
@@ -250,17 +250,17 @@ private[core] object ASTValidation {
     }
   }
 
-  private def isGeneric(typeName: String, classDefinition: ClassDefinition, methodDefinition: MethodDefinition)(implicit context: Context): Boolean = {
+  def isGeneric(typeName: String, classDefinition: ClassDefinition, methodDefinition: MethodDefinition)(implicit context: Context): Boolean = {
     val isGenericTypeFromClass = classDefinition.genericTypes.contains(typeName)
     val isGenericTypeFromMethod = methodDefinition.genericTypes.contains(typeName)
     isGenericTypeFromClass || isGenericTypeFromMethod
   }
 
-  private def validateExpressions(expressions: Expression*)(implicit context: Context): Validation = {
+  def validateExpressions(expressions: Expression*)(implicit context: Context): Validation = {
     Validation.join(expressions.map(validateExpression))
   }
 
-  private def validateBooleanExpression(left: Expression, right: Expression)(implicit context: Context): Validation = {
+  def validateBooleanExpression(left: Expression, right: Expression)(implicit context: Context): Validation = {
     validateExpressions(left, right).verifyingAlso {
       lazy val leftReturnType = ASTHelper.getReturnTypeOfExpression(left)
       lazy val rightReturnType = ASTHelper.getReturnTypeOfExpression(right)
@@ -274,7 +274,7 @@ private[core] object ASTValidation {
     }
   }
 
-  private def verifyTypeReference(aliasType: AliasType)(implicit context: Context) = {
+  def verifyTypeReference(aliasType: AliasType)(implicit context: Context): Validation = {
     if (context.isTypeAvailable(aliasType.alias.typeName)) {
       Valid
     } else {
@@ -282,7 +282,7 @@ private[core] object ASTValidation {
     }
   }
 
-  private def validateTypeReferencesOfMethod(methodDefinition: MethodDefinition)(implicit context: Context): Validation = {
+  def validateTypeReferencesOfMethod(methodDefinition: MethodDefinition)(implicit context: Context): Validation = {
     methodDefinition match {
       case _: NativeMethodDefinition =>
         Valid
@@ -291,7 +291,7 @@ private[core] object ASTValidation {
     }
   }
 
-  private[parser] def validateTypeReferenceOfExpression(expression: Expression)(implicit context: Context): Validation = {
+  def validateTypeReferenceOfExpression(expression: Expression)(implicit context: Context): Validation = {
     expression match {
       case _: LogicalExpression => Valid
       case _: CalculatorExpression => Valid

--- a/src/main/scala/definiti/core/parser/CoreDefinitionASTParser.scala
+++ b/src/main/scala/definiti/core/parser/CoreDefinitionASTParser.scala
@@ -41,7 +41,6 @@ private[core] object CoreDefinitionASTParser {
       name = context.attributeName.getText,
       typeReference = TypeReference(context.attributeType.getText, processGenericTypeList(context.genericTypeList())),
       comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
-      genericTypes = processGenericTypeList(context.genericTypeList()),
       verifications = Seq.empty,
       range = getRangeFromContext(context)
     )

--- a/src/main/scala/definiti/core/parser/CoreDefinitionASTParser.scala
+++ b/src/main/scala/definiti/core/parser/CoreDefinitionASTParser.scala
@@ -42,6 +42,7 @@ private[core] object CoreDefinitionASTParser {
       typeReference = TypeReference(context.attributeType.getText, processGenericTypeList(context.genericTypeList())),
       comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
       genericTypes = processGenericTypeList(context.genericTypeList()),
+      verifications = Seq.empty,
       range = getRangeFromContext(context)
     )
   }

--- a/src/main/scala/definiti/core/parser/DefinitiASTParser.scala
+++ b/src/main/scala/definiti/core/parser/DefinitiASTParser.scala
@@ -71,8 +71,13 @@ private[core] object DefinitiASTParser {
       typeReference = TypeReference(context.attributeType.getText, processGenericTypeList(context.genericTypeList())),
       comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
       genericTypes = processGenericTypeList(context.genericTypeList()),
+      verifications = processAttributeVerification(context.attributeVerifications()),
       range = getRangeFromContext(context)
     )
+  }
+
+  private def processAttributeVerification(context: AttributeVerificationsContext): Seq[String] = {
+    scalaSeq(context.IDENTIFIER()).map(_.getText)
   }
 
   private def processTypeVerification(context: TypeVerificationContext): TypeVerification = {

--- a/src/main/scala/definiti/core/parser/DefinitiASTParser.scala
+++ b/src/main/scala/definiti/core/parser/DefinitiASTParser.scala
@@ -70,7 +70,6 @@ private[core] object DefinitiASTParser {
       name = context.attributeName.getText,
       typeReference = TypeReference(context.attributeType.getText, processGenericTypeList(context.genericTypeList())),
       comment = Option(context.DOC_COMMENT()).map(_.getText).map(extractDocComment),
-      genericTypes = processGenericTypeList(context.genericTypeList()),
       verifications = processAttributeVerification(context.attributeVerifications()),
       range = getRangeFromContext(context)
     )

--- a/src/main/scala/definiti/core/parser/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/parser/ProjectLinking.scala
@@ -81,7 +81,8 @@ private[core] object ProjectLinking {
 
   private def injectLinksIntoAttributes(attributeDefinition: AttributeDefinition, typeMapping: TypeMapping): AttributeDefinition = {
     attributeDefinition.copy(
-      typeReference = injectLinksIntoTypeReference(attributeDefinition.typeReference, typeMapping)
+      typeReference = injectLinksIntoTypeReference(attributeDefinition.typeReference, typeMapping),
+      verifications = attributeDefinition.verifications.map(getLink(_, typeMapping))
     )
   }
 

--- a/src/test/scala/definiti/core/api/ASTHelperSpec.scala
+++ b/src/test/scala/definiti/core/api/ASTHelperSpec.scala
@@ -18,14 +18,14 @@ class ASTHelperSpec extends FlatSpec with Matchers {
   val dateDefinition = NativeClassDefinition(
     "Date",
     Seq(),
-    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), Seq(), noRange)),
+    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), noRange)),
     Seq(),
     None
   )
   val listDefinition = NativeClassDefinition(
     "List",
     Seq("A"),
-    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), Seq(), noRange)),
+    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), noRange)),
     Seq(
       NativeMethodDefinition("nonEmpty", Seq(), Seq(), TypeReference("Boolean", Seq()), None),
       NativeMethodDefinition("randomElement", Seq(), Seq(), TypeReference("A", Seq()), None)

--- a/src/test/scala/definiti/core/api/ASTHelperSpec.scala
+++ b/src/test/scala/definiti/core/api/ASTHelperSpec.scala
@@ -1,6 +1,5 @@
 package definiti.core.api
 
-import definiti.core.parser.{ASTValidation, Valid}
 import definiti.core._
 import definiti.core.utils.Core
 import org.scalatest.{FlatSpec, Matchers}
@@ -19,14 +18,14 @@ class ASTHelperSpec extends FlatSpec with Matchers {
   val dateDefinition = NativeClassDefinition(
     "Date",
     Seq(),
-    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), noRange)),
+    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), Seq(), noRange)),
     Seq(),
     None
   )
   val listDefinition = NativeClassDefinition(
     "List",
     Seq("A"),
-    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), noRange)),
+    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), Seq(), noRange)),
     Seq(
       NativeMethodDefinition("nonEmpty", Seq(), Seq(), TypeReference("Boolean", Seq()), None),
       NativeMethodDefinition("randomElement", Seq(), Seq(), TypeReference("A", Seq()), None)

--- a/src/test/scala/definiti/core/generators/ASTGenerator.scala
+++ b/src/test/scala/definiti/core/generators/ASTGenerator.scala
@@ -1,0 +1,168 @@
+package definiti.core.generators
+
+import definiti.core.{AttributeDefinition, Context, DefinedFunction, ParameterDefinition, Position, Range, ReferenceContext, TypeReference}
+import org.scalacheck.{Arbitrary, Gen}
+
+import scala.annotation.tailrec
+
+object ASTGenerator {
+  def anyFunction(implicit context: Context): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOf(anyParameterDefinition)
+    body <- ExpressionGenerator.anyExpression
+    genericTypes <- Gen.listOf(anyIdentifier)
+    range <- anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  // We do not generate recursive ParameterDefinition (eg: List[Option[List[String]]]) because of possible stack overflows
+  def anyParameterDefinition(implicit context: Context): Gen[ParameterDefinition] = for {
+    name <- anyIdentifier
+    typeReference <- anyTypeReference
+    range <- anyRange
+  } yield {
+    ParameterDefinition(
+      name = name,
+      typeReference = typeReference,
+      range = range
+    )
+  }
+
+  def anyTypeReference(implicit context: Context): Gen[TypeReference] = for {
+    typeName <- anyIdentifier
+  } yield {
+    TypeReference(
+      typeName = typeName,
+      genericTypes = Seq.empty
+    )
+  }
+
+  def referencedTypeReference(implicit context: ReferenceContext): Gen[TypeReference] = {
+    def process(n: Int): Gen[TypeReference] = n match {
+      case 0 =>
+        for {
+          classDefinition <- Gen.oneOf(context.classes)
+        } yield {
+          TypeReference(
+            typeName = classDefinition.canonicalName,
+            genericTypes = classDefinition.genericTypes.map(_ => TypeReference(typeName = "Boolean", genericTypes = Seq.empty))
+          )
+        }
+      case other if other > 0 =>
+        for {
+          classDefinition <- Gen.oneOf(context.classes)
+          genericTypes <- Gen.listOfN(classDefinition.genericTypes.length, process(other - 1))
+        } yield {
+          TypeReference(
+            typeName = classDefinition.canonicalName,
+            genericTypes = genericTypes
+          )
+        }
+    }
+
+    process(2)
+  }
+
+  def anyAttributeDefinition(implicit context: ReferenceContext): Gen[AttributeDefinition] = for {
+    name <- anyIdentifier
+    typeReference <- anyTypeReference
+    comment <- Gen.option(anyIdentifier)
+    verifications <- Gen.listOf(anyIdentifier)
+    range <- anyRange
+  } yield {
+    AttributeDefinition(
+      name,
+      typeReference,
+      comment,
+      verifications,
+      range
+    )
+  }
+
+  def referencedAttributeDefinition(implicit context: ReferenceContext): Gen[AttributeDefinition] = for {
+    attributeDefinition <- anyAttributeDefinition
+    typeReference <- referencedTypeReference
+    verifications <- Gen.listOf(referencedVerificationIdentifier)
+  } yield {
+    attributeDefinition.copy(
+      typeReference = typeReference,
+      verifications = verifications
+    )
+  }
+
+  def attributeDefinitionWithNonReferencedType(implicit context: ReferenceContext): Gen[AttributeDefinition] = for {
+    attributeDefinition <- anyAttributeDefinition
+  } yield {
+    attributeDefinition.copy(
+      typeReference = makeNonReferenced(attributeDefinition.typeReference)
+    )
+  }
+
+  def attributeDefinitionWithNonReferencedVerification(implicit context: ReferenceContext): Gen[AttributeDefinition] = for {
+    attributeDefinition <- anyAttributeDefinition
+    verificationName <- anyIdentifier
+  } yield {
+    attributeDefinition.copy(
+      verifications = attributeDefinition.verifications :+ makeNonReferenced(verificationName)
+    )
+  }
+
+  def referencedVerificationIdentifier(implicit context: ReferenceContext): Gen[String] = for {
+    verification <- Gen.oneOf(context.verifications)
+  } yield {
+    verification.canonicalName
+  }
+
+  def anyIdentifier(implicit context: Context): Gen[String] = Gen.alphaNumStr
+
+  def anyPackageName(implicit context: Context): Gen[String] = Gen.listOf(Gen.frequency((1, '.'), (10, Gen.alphaNumChar))).map(_.mkString)
+
+  def anyString(implicit context: Context): Gen[String] = Arbitrary.arbString.arbitrary
+
+  def anyRange(implicit context: Context): Gen[Range] = for {
+    firstLine <- Gen.choose(0, Int.MaxValue)
+    secondLine <- Gen.choose(0, Int.MaxValue)
+    firstColumn <- Gen.choose(0, Int.MaxValue)
+    secondColumn <- Gen.choose(0, Int.MaxValue)
+  } yield {
+    val lineStart = Math.min(firstLine, secondLine)
+    val lineEnd = Math.max(firstLine, secondLine)
+    val columnStart = if (lineStart == lineEnd) Math.min(firstColumn, secondColumn) else firstColumn
+    val columnEnd = if (lineStart == lineEnd) Math.max(firstColumn, secondColumn) else secondColumn
+    Range(
+      start = Position(line = lineStart, column = columnStart),
+      end = Position(line = lineEnd, column = columnEnd)
+    )
+  }
+
+  def listOfGenericTypeDefinition(implicit context: Context): Gen[Seq[String]] = {
+    Generators.listOfBoundedSize(0, 2, ASTGenerator.anyIdentifier)
+  }
+
+  def listOfGenericType(implicit context: Context): Gen[Seq[TypeReference]] = {
+    Generators.listOfBoundedSize(0, 2, ASTGenerator.anyTypeReference)
+  }
+
+  def makeNonReferenced(name: String)(implicit context: ReferenceContext): String = {
+    val forbiddenNames = context.verifications.map(_.canonicalName) ++ context.classes.map(_.canonicalName)
+    @tailrec def process(currentName: String): String = {
+      if (forbiddenNames.contains(currentName)) {
+        process(currentName + Gen.alphaNumChar.sample.getOrElse('a'))
+      } else {
+        currentName
+      }
+    }
+    process(name)
+  }
+
+  def makeNonReferenced(typeReference: TypeReference)(implicit context: ReferenceContext): TypeReference = {
+    typeReference.copy(
+      typeName = makeNonReferenced(typeReference.typeName)
+    )
+  }
+}

--- a/src/test/scala/definiti/core/generators/ContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/ContextGenerator.scala
@@ -1,0 +1,48 @@
+package definiti.core.generators
+
+import definiti.core.ReferenceContext
+import org.scalacheck.Gen
+
+import scala.annotation.tailrec
+
+object ContextGenerator {
+  def anyContext(implicit context: ReferenceContext): Gen[ReferenceContext] = for {
+    verifications <- Gen.listOf(VerificationGenerator.anyReferencedValidVerification)
+    types <- Gen.listOf(TypeGenerator.anyType)
+  } yield {
+    val usedNamed = context.verifications.map(_.canonicalName) ++ context.classes.map(_.canonicalName)
+    val noDuplicatedVerifications = verifications.filterNot(verification => usedNamed.contains(verification.canonicalName))
+    val noDuplicatedTypes = types.filterNot(aType => usedNamed.contains(aType.canonicalName))
+
+    context.copy(
+      classes = context.classes ++ noDuplicatedTypes,
+      verifications = context.verifications ++ noDuplicatedVerifications
+    )
+  }
+
+  def anyContextWithNonEmptyVerifications(implicit context: ReferenceContext): Gen[ReferenceContext] = for {
+    verifications <- Gen.nonEmptyListOf(VerificationGenerator.anyReferencedValidVerification)
+    types <- Gen.listOf(TypeGenerator.anyType)
+  } yield {
+    val usedNamed = context.verifications.map(_.canonicalName) ++ context.classes.map(_.canonicalName)
+    val noDuplicatedVerifications = verifications.map(verification => verification.copy(name = makeUnique(verification.name, context)))
+    val noDuplicatedTypes = types.filterNot(aType => usedNamed.contains(aType.canonicalName))
+
+    context.copy(
+      classes = context.classes ++ noDuplicatedTypes,
+      verifications = context.verifications ++ noDuplicatedVerifications
+    )
+  }
+
+  @tailrec
+  def makeUnique(name: String, context: ReferenceContext): String = {
+    def existsClassWithName = context.classes.exists(_.canonicalName == name)
+    def existsVerificationWithName = context.verifications.exists(_.canonicalName == name)
+    if (existsClassWithName || existsVerificationWithName) {
+      val char = Gen.alphaNumChar.sample.getOrElse('a')
+      makeUnique(name + char, context)
+    } else {
+      name
+    }
+  }
+}

--- a/src/test/scala/definiti/core/generators/ExpressionGenerator.scala
+++ b/src/test/scala/definiti/core/generators/ExpressionGenerator.scala
@@ -1,0 +1,28 @@
+package definiti.core.generators
+
+import definiti.core.{BooleanValue, Context, Expression}
+import definiti.core.generators.ASTGenerator.anyRange
+import org.scalacheck.Gen
+
+object ExpressionGenerator {
+  // TODO: make it complete when needed
+  def anyExpression(implicit context: Context): Gen[Expression] = for {
+    range <- anyRange
+  } yield {
+    BooleanValue(value = true, range = range)
+  }
+
+  // TODO: make it complete when needed
+  def anyBooleanExpression(implicit context: Context): Gen[Expression] = for {
+    range <- anyRange
+  } yield {
+    BooleanValue(value = true, range = range)
+  }
+
+  // TODO: make it complete when needed
+  def anyReferencedExpression(implicit context: Context): Gen[Expression] = for {
+    range <- anyRange
+  } yield {
+    BooleanValue(value = true, range = range)
+  }
+}

--- a/src/test/scala/definiti/core/generators/FunctionGenerator.scala
+++ b/src/test/scala/definiti/core/generators/FunctionGenerator.scala
@@ -1,0 +1,142 @@
+package definiti.core.generators
+
+import definiti.core.{DefinedFunction, ParameterDefinition, ReferenceContext}
+import org.scalacheck.Gen
+
+object FunctionGenerator {
+  def anyFunction(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOf(anyParameterDefinition)
+    body <- ExpressionGenerator.anyExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyFunctionWithParameters(numberOrParameters: Int)(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOfN(numberOrParameters, anyParameterDefinition)
+    body <- ExpressionGenerator.anyExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyFunctionReturningBoolean(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOf(anyParameterDefinition)
+    body <- ExpressionGenerator.anyBooleanExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyFunctionWithParametersReturningBoolean(numberOrParameters: Int)(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOfN(numberOrParameters, anyParameterDefinition)
+    body <- ExpressionGenerator.anyBooleanExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyReferencedFunction(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOf(anyReferencedParameterDefinition)
+    body <- ExpressionGenerator.anyReferencedExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyReferencedFunctionWithParameters(numberOrParameters: Int)(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOfN(numberOrParameters, anyReferencedParameterDefinition)
+    body <- ExpressionGenerator.anyReferencedExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyReferencedFunctionReturningBoolean(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOf(anyReferencedParameterDefinition)
+    body <- ExpressionGenerator.anyBooleanExpression
+    genericTypes <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyReferencedFunctionWithParametersReturningBoolean(numberOrParameters: Int)(implicit context: ReferenceContext): Gen[DefinedFunction] = for {
+    parameters <- Gen.listOfN(numberOrParameters, anyReferencedParameterDefinition)
+    body <- ExpressionGenerator.anyBooleanExpression
+    genericTypes <- ASTGenerator.listOfGenericTypeDefinition
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedFunction(
+      parameters = parameters,
+      body = body,
+      genericTypes = genericTypes,
+      range = range
+    )
+  }
+
+  def anyParameterDefinition(implicit context: ReferenceContext): Gen[ParameterDefinition] = for {
+    name <- ASTGenerator.anyIdentifier
+    typeReference <- ASTGenerator.anyTypeReference
+    range <- ASTGenerator.anyRange
+  } yield {
+    ParameterDefinition(
+      name,
+      typeReference,
+      range
+    )
+  }
+
+  def anyReferencedParameterDefinition(implicit context: ReferenceContext): Gen[ParameterDefinition] = for {
+    name <- ASTGenerator.anyIdentifier
+    typeReference <- ASTGenerator.referencedTypeReference
+    range <- ASTGenerator.anyRange
+  } yield {
+    ParameterDefinition(
+      name,
+      typeReference,
+      range
+    )
+  }
+}

--- a/src/test/scala/definiti/core/generators/Generators.scala
+++ b/src/test/scala/definiti/core/generators/Generators.scala
@@ -1,0 +1,10 @@
+package definiti.core.generators
+
+import org.scalacheck.Gen
+
+object Generators {
+  def listOfBoundedSize[A](min: Int, max: Int, gen: Gen[A]): Gen[List[A]] = for {
+    numElems <- Gen.choose(min, max)
+    elems <- Gen.listOfN(numElems, gen)
+  } yield elems
+}

--- a/src/test/scala/definiti/core/generators/TypeGenerator.scala
+++ b/src/test/scala/definiti/core/generators/TypeGenerator.scala
@@ -1,0 +1,86 @@
+package definiti.core.generators
+
+import definiti.core._
+import org.scalacheck.Gen
+
+object TypeGenerator {
+  def anyType(implicit context: ReferenceContext): Gen[Type] = Gen.oneOf(anyDefinedType, anyAliasType)
+
+  def anyDefinedType(implicit context: ReferenceContext): Gen[DefinedType] = for {
+    name <- ASTGenerator.anyIdentifier
+    packageName <- ASTGenerator.anyPackageName
+    genericTypes <- ASTGenerator.listOfGenericTypeDefinition
+    attributes <- listOfAttributes
+    verifications <- listOfTypeVerifications
+    inherited <- Gen.someOf(context.verifications)
+    comment <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    DefinedType(
+      name,
+      packageName,
+      genericTypes,
+      attributes,
+      verifications,
+      inherited.map(_.canonicalName),
+      comment,
+      range
+    )
+  }
+
+  def anyAliasType(implicit context: ReferenceContext): Gen[AliasType] = for {
+    name <- ASTGenerator.anyIdentifier
+    packageName <- ASTGenerator.anyPackageName
+    genericTypes <- ASTGenerator.listOfGenericTypeDefinition
+    alias <- ASTGenerator.referencedTypeReference
+    inherited <- Gen.someOf(context.verifications)
+    comment <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    AliasType(
+      name,
+      packageName,
+      genericTypes,
+      alias,
+      inherited.map(_.canonicalName),
+      comment,
+      range
+    )
+  }
+
+  def anyAttributeDefinition(implicit context: Context): Gen[AttributeDefinition] = for {
+    name <- ASTGenerator.anyIdentifier
+    typeReference <- ASTGenerator.anyTypeReference
+    comment <- Gen.option(ASTGenerator.anyString)
+    verifications <- Gen.listOf(ASTGenerator.anyIdentifier)
+    range <- ASTGenerator.anyRange
+  } yield {
+    AttributeDefinition(
+      name = name,
+      typeReference = typeReference,
+      comment = comment,
+      verifications = verifications,
+      range = range
+    )
+  }
+
+  def anyTypeVerification(implicit context: ReferenceContext): Gen[TypeVerification] = for {
+    message <- ASTGenerator.anyString
+    function <- FunctionGenerator.anyFunctionWithParametersReturningBoolean(1)
+    range <- ASTGenerator.anyRange
+  } yield {
+    TypeVerification(
+      message,
+      function,
+      range
+    )
+  }
+
+  def listOfAttributes(implicit context: ReferenceContext): Gen[List[AttributeDefinition]] = {
+    Generators.listOfBoundedSize(0, 5, anyAttributeDefinition)
+  }
+
+  def listOfTypeVerifications(implicit context: ReferenceContext): Gen[List[TypeVerification]] = {
+    Generators.listOfBoundedSize(0, 3, anyTypeVerification)
+  }
+}

--- a/src/test/scala/definiti/core/generators/VerificationGenerator.scala
+++ b/src/test/scala/definiti/core/generators/VerificationGenerator.scala
@@ -1,0 +1,78 @@
+package definiti.core.generators
+
+import definiti.core._
+import org.scalacheck.Gen
+
+object VerificationGenerator {
+  def anyVerification(implicit context: ReferenceContext): Gen[Verification] = for {
+    name <- ASTGenerator.anyIdentifier
+    packageName <- ASTGenerator.anyPackageName
+    message <- ASTGenerator.anyString
+    function <- FunctionGenerator.anyFunction
+    comment <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    Verification(
+      name = name,
+      packageName = packageName,
+      message = message,
+      function = function,
+      comment = comment,
+      range = range
+    )
+  }
+
+  def anyReferencedVerification(implicit context: ReferenceContext): Gen[Verification] = for {
+    name <- ASTGenerator.anyIdentifier
+    packageName <- ASTGenerator.anyPackageName
+    message <- ASTGenerator.anyString
+    function <- FunctionGenerator.anyReferencedFunction
+    comment <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    Verification(
+      name = name,
+      packageName = packageName,
+      message = message,
+      function = function,
+      comment = comment,
+      range = range
+    )
+  }
+
+  def anyValidVerification(implicit context: ReferenceContext): Gen[Verification] = for {
+    name <- ASTGenerator.anyIdentifier
+    packageName <- ASTGenerator.anyPackageName
+    message <- ASTGenerator.anyString
+    function <- FunctionGenerator.anyFunctionWithParametersReturningBoolean(1)
+    comment <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    Verification(
+      name = name,
+      packageName = packageName,
+      message = message,
+      function = function,
+      comment = comment,
+      range = range
+    )
+  }
+
+  def anyReferencedValidVerification(implicit context: ReferenceContext): Gen[Verification] = for {
+    name <- ASTGenerator.anyIdentifier
+    packageName <- ASTGenerator.anyPackageName
+    message <- ASTGenerator.anyString
+    function <- FunctionGenerator.anyReferencedFunctionWithParametersReturningBoolean(1)
+    comment <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    Verification(
+      name = name,
+      packageName = packageName,
+      message = message,
+      function = function,
+      comment = comment,
+      range = range
+    )
+  }
+}

--- a/src/test/scala/definiti/core/parser/ASTValidationAttributeDefinitionSpec.scala
+++ b/src/test/scala/definiti/core/parser/ASTValidationAttributeDefinitionSpec.scala
@@ -1,0 +1,43 @@
+package definiti.core.parser
+
+import definiti.core.generators.{ASTGenerator, ContextGenerator}
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class ASTValidationAttributeDefinitionSpec extends FlatSpec with Matchers with PropertyChecks with CoreParser {
+  "ASTValidation.validateAttributeDefinition" should "accept any attribute with a referenced type" in {
+    val testGenerator = for {
+      context <- ContextGenerator.anyContextWithNonEmptyVerifications(coreContext)
+      attributeDefinition <- ASTGenerator.referencedAttributeDefinition(context)
+    } yield {
+      (context, attributeDefinition)
+    }
+    forAll(testGenerator) { case (context, attributeDefinition) =>
+      ASTValidation.validateAttributeDefinition(attributeDefinition)(context) should be(Valid)
+    }
+  }
+
+  it should "refuse any attribute with a non-referenced type" in {
+    val testGenerator = for {
+      context <- ContextGenerator.anyContextWithNonEmptyVerifications(coreContext)
+      attributeDefinition <- ASTGenerator.attributeDefinitionWithNonReferencedType(context)
+    } yield {
+      (context, attributeDefinition)
+    }
+    forAll(testGenerator) { case (context, attributeDefinition) =>
+      ASTValidation.validateAttributeDefinition(attributeDefinition)(context) should be(an[Invalid])
+    }
+  }
+
+  it should "refuse any attribute with a non-referenced verification" in {
+    val testGenerator = for {
+      context <- ContextGenerator.anyContextWithNonEmptyVerifications(coreContext)
+      attributeDefinition <- ASTGenerator.attributeDefinitionWithNonReferencedVerification(context)
+    } yield {
+      (context, attributeDefinition)
+    }
+    forAll(testGenerator) { case (context, attributeDefinition) =>
+      ASTValidation.validateAttributeDefinition(attributeDefinition)(context) should be(an[Invalid])
+    }
+  }
+}

--- a/src/test/scala/definiti/core/parser/ASTValidationSpec.scala
+++ b/src/test/scala/definiti/core/parser/ASTValidationSpec.scala
@@ -17,14 +17,14 @@ class ASTValidationSpec extends FlatSpec with Matchers {
   val dateDefinition = NativeClassDefinition(
     "Date",
     Seq(),
-    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), Seq(), noRange)),
+    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), noRange)),
     Seq(),
     None
   )
   val listDefinition = NativeClassDefinition(
     "List",
     Seq("A"),
-    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), Seq(), noRange)),
+    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), noRange)),
     Seq(
       NativeMethodDefinition("nonEmpty", Seq(), Seq(), TypeReference("Boolean", Seq()), None),
       NativeMethodDefinition("randomElement", Seq(), Seq(), TypeReference("A", Seq()), None)

--- a/src/test/scala/definiti/core/parser/ASTValidationSpec.scala
+++ b/src/test/scala/definiti/core/parser/ASTValidationSpec.scala
@@ -17,14 +17,14 @@ class ASTValidationSpec extends FlatSpec with Matchers {
   val dateDefinition = NativeClassDefinition(
     "Date",
     Seq(),
-    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), noRange)),
+    Seq(AttributeDefinition("timestamp", TypeReference("Number", Seq()), None, Seq(), Seq(), noRange)),
     Seq(),
     None
   )
   val listDefinition = NativeClassDefinition(
     "List",
     Seq("A"),
-    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), noRange)),
+    Seq(AttributeDefinition("head", TypeReference("A", Seq()), None, Seq(), Seq(), noRange)),
     Seq(
       NativeMethodDefinition("nonEmpty", Seq(), Seq(), TypeReference("Boolean", Seq()), None),
       NativeMethodDefinition("randomElement", Seq(), Seq(), TypeReference("A", Seq()), None)

--- a/src/test/scala/definiti/core/parser/ASTValidationVerificationSpec.scala
+++ b/src/test/scala/definiti/core/parser/ASTValidationVerificationSpec.scala
@@ -1,0 +1,34 @@
+package definiti.core.parser
+
+import definiti.core.generators.VerificationGenerator
+import definiti.core.{BooleanValue, NumberValue}
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class ASTValidationVerificationSpec extends FlatSpec with Matchers with PropertyChecks with CoreParser {
+  "ASTValidation.validateVerification" should "accept a function returning a Boolean" in {
+    implicit val context = coreContext
+    forAll(VerificationGenerator.anyVerification) { verification =>
+      val normalizedVerification = verification.copy(
+        function = verification.function.copy(
+          body = BooleanValue(value = true, range = verification.function.body.range)
+        )
+      )
+
+      ASTValidation.validateVerification(normalizedVerification) should be(Valid)
+    }
+  }
+
+  it should "refuse a function returning a number" in {
+    implicit val context = coreContext
+    forAll(VerificationGenerator.anyVerification) { verification =>
+      val normalizedVerification = verification.copy(
+        function = verification.function.copy(
+          body = NumberValue(value = 1, range = verification.function.body.range)
+        )
+      )
+
+      ASTValidation.validateVerification(normalizedVerification) should be(an[Invalid])
+    }
+  }
+}

--- a/src/test/scala/definiti/core/parser/CoreParser.scala
+++ b/src/test/scala/definiti/core/parser/CoreParser.scala
@@ -1,0 +1,37 @@
+package definiti.core.parser
+
+import java.nio.file.{Files, Path, Paths}
+
+import definiti.core.parser.antlr.{CoreDefinitionLexer, CoreDefinitionParser}
+import definiti.core.utils.CollectionUtils.scalaSeq
+import definiti.core.{ClassDefinition, ReferenceContext}
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+
+trait CoreParser {
+  lazy val core: Seq[ClassDefinition] = {
+    extractCoreDefinitionFiles()
+      .map(_.toAbsolutePath.toString)
+      .flatMap(parseCoreDefinitionFile)
+  }
+
+  lazy val coreContext: ReferenceContext = {
+    ReferenceContext(
+      classes = core,
+      verifications = Seq.empty
+    )
+  }
+
+  private def extractCoreDefinitionFiles(): Seq[Path] = {
+    val source = Paths.get("src", "main", "resources", "api")
+    scalaSeq(Files.find(source, 1000, (path, _) => String.valueOf(path).endsWith(".definition")))
+  }
+
+  private def parseCoreDefinitionFile(fileName: String): Seq[ClassDefinition] = {
+    val in = CharStreams.fromFileName(fileName)
+    val lexer = new CoreDefinitionLexer(in)
+    val tokens = new CommonTokenStream(lexer)
+    val parser = new CoreDefinitionParser(tokens)
+    val coreDefinition = parser.coreDefinition()
+    CoreDefinitionASTParser.definitionContextToAST(coreDefinition)
+  }
+}


### PR DESCRIPTION
* Add `attributeVerifications` in antlr definition
* Update the model to include verifications in attributes
* Consider this new element into `DefinitiASTParser`
* Update `CoreDefinitionASTParser` and tests to adapt the new model
* Create a new sample `src2` using this new function
* Resolves #9