### PR TITLE
15 simplify declaration in type verification

### DIFF
--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -74,8 +74,10 @@ attributeVerifications: ('verifying' IDENTIFIER)*;
 typeVerification:
   'verify' '{'
     verificationMessage=STRING
-    function
+    typeVerificationFunction
   '}';
+
+typeVerificationFunction: '(' IDENTIFIER ')' '=>' '{' chainedExpression '}';
 
 aliasType :
   DOC_COMMENT?

--- a/src/main/resources/samples/first.def
+++ b/src/main/resources/samples/first.def
@@ -32,7 +32,7 @@ type Period {
 
   verify {
     "end should be after start"
-    (period: Period) => { period.end > period.start || period.end == period.start }
+    (period) => { period.end > period.start || period.end == period.start }
   }
 }
 
@@ -58,7 +58,7 @@ type MultiplePeriod {
   verify {
     "end should be after start"
     // The second part tests the generic system.
-    (multiplePeriod: MultiplePeriod) => {
+    (multiplePeriod) => {
       multiplePeriod.periods.nonEmpty() && multiplePeriod.periods.head.start.timestamp > 0
     }
   }
@@ -69,7 +69,7 @@ type NonEmptyList[A] {
 
   verify {
     "The list should not be empty"
-    (nonEmptyList: NonEmptyList[A]) => {
+    (nonEmptyList) => {
       nonEmptyList.values.nonEmpty()
     }
   }
@@ -89,7 +89,7 @@ type Balance {
 
   verify {
     "The sum of entries must be 0"
-    (balance: Balance) => {
+    (balance) => {
       balance.entries.foldLeft[Number](0, (acc: Number, current: Number) => { acc + current }) > 0
     }
   }

--- a/src/main/scala/definiti/core/AST.scala
+++ b/src/main/scala/definiti/core/AST.scala
@@ -168,7 +168,13 @@ case class DefinedFunction(parameters: Seq[ParameterDefinition], body: Expressio
 case class Parameter(name: String, typeReference: TypeReference, range: Range)
 
 case class Verification(name: String, packageName: String, message: String, function: DefinedFunction, comment: Option[String], range: Range) {
-  def canonicalName: String = packageName + "." + name
+  def canonicalName: String = {
+    if (packageName.nonEmpty) {
+      packageName + "." + name
+    } else {
+      name
+    }
+  }
 }
 
 sealed trait Type extends ClassDefinition {
@@ -178,11 +184,23 @@ sealed trait Type extends ClassDefinition {
 case class DefinedType(name: String, packageName: String, genericTypes: Seq[String], attributes: Seq[AttributeDefinition], verifications: Seq[TypeVerification], inherited: Seq[String], comment: Option[String], range: Range) extends Type {
   def methods: Seq[MethodDefinition] = Seq()
 
-  override def canonicalName: String = packageName + "." + name
+  override def canonicalName: String = {
+    if (packageName.nonEmpty) {
+      packageName + "." + name
+    } else {
+      name
+    }
+  }
 }
 
 case class AliasType(name: String, packageName: String, genericTypes: Seq[String], alias: TypeReference, inherited: Seq[String], comment: Option[String], range: Range) extends Type {
-  override def canonicalName: String = packageName + "." + name
+  override def canonicalName: String = {
+    if (packageName.nonEmpty) {
+      packageName + "." + name
+    } else {
+      name
+    }
+  }
 }
 
 case class TypeVerification(message: String, function: DefinedFunction, range: Range)

--- a/src/main/scala/definiti/core/Boot.scala
+++ b/src/main/scala/definiti/core/Boot.scala
@@ -6,7 +6,7 @@ import org.kiama.output.PrettyPrinter._
 object Boot extends App {
   try {
     val configuration = Configuration(
-      source = Paths.get("src", "main", "resources", "samples", "src2"),
+      source = Paths.get("src", "main", "resources", "samples", "first.def"),
       core = CoreConfiguration(
         source = Paths.get("src", "main", "resources", "api")
       )

--- a/src/main/scala/definiti/core/parser/DefinitiASTParser.scala
+++ b/src/main/scala/definiti/core/parser/DefinitiASTParser.scala
@@ -41,7 +41,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processVerification(context: VerificationContext): Verification = {
+  def processVerification(context: VerificationContext): Verification = {
     Verification(
       name = context.verificationName.getText,
       packageName = NOT_DEFINED,
@@ -52,7 +52,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processDefinedType(context: DefinedTypeContext): DefinedType = {
+  def processDefinedType(context: DefinedTypeContext): DefinedType = {
     val typeName = context.typeName.getText
     DefinedType(
       name = typeName,
@@ -66,7 +66,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processAttributeDefinition(context: AttributeDefinitionContext): AttributeDefinition = {
+  def processAttributeDefinition(context: AttributeDefinitionContext): AttributeDefinition = {
     AttributeDefinition(
       name = context.attributeName.getText,
       typeReference = TypeReference(context.attributeType.getText, processGenericTypeList(context.genericTypeList())),
@@ -76,11 +76,11 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processAttributeVerification(context: AttributeVerificationsContext): Seq[String] = {
+  def processAttributeVerification(context: AttributeVerificationsContext): Seq[String] = {
     scalaSeq(context.IDENTIFIER()).map(_.getText)
   }
 
-  private def processTypeVerification(context: TypeVerificationContext, typeName: String): TypeVerification = {
+  def processTypeVerification(context: TypeVerificationContext, typeName: String): TypeVerification = {
     TypeVerification(
       extractStringContent(context.verificationMessage.getText),
       processTypeVerificationFunction(context.typeVerificationFunction(), typeName),
@@ -88,7 +88,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processTypeVerificationFunction(context: TypeVerificationFunctionContext, typeName: String): DefinedFunction = {
+  def processTypeVerificationFunction(context: TypeVerificationFunctionContext, typeName: String): DefinedFunction = {
     val parameters = Seq(ParameterDefinition(
       name = context.IDENTIFIER().getText,
       typeReference = TypeReference(typeName, Seq.empty),
@@ -103,7 +103,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processAliasType(context: AliasTypeContext): AliasType = {
+  def processAliasType(context: AliasTypeContext): AliasType = {
     AliasType(
       name = context.typeName.getText,
       packageName = NOT_DEFINED,
@@ -118,7 +118,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processFunction(context: FunctionContext): DefinedFunction = {
+  def processFunction(context: FunctionContext): DefinedFunction = {
     val parameters = scalaSeq(context.parameterListDefinition().parameterDefinition()).map(processParameter)
     implicit val scope = Scope(parametersToVariables(parameters))
     DefinedFunction(
@@ -131,7 +131,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processParameter(context: ParameterDefinitionContext): ParameterDefinition = {
+  def processParameter(context: ParameterDefinitionContext): ParameterDefinition = {
     ParameterDefinition(
       name = context.parameterName.getText,
       typeReference = TypeReference(context.parameterType.getText, processGenericTypeList(context.genericTypeList())),
@@ -139,14 +139,14 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processChainedExpression(context: ChainedExpressionContext)(implicit scope: Scope): Expression = {
+  def processChainedExpression(context: ChainedExpressionContext)(implicit scope: Scope): Expression = {
     scalaSeq(context.expression()) match {
       case head :: Nil => processExpression(head)
       case expressions => CombinedExpression(expressions.map(processExpression), getRangeFromContext(context))
     }
   }
 
-  private def processExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     if (context.parenthesis != null) {
       processParenthesisExpression(context)
     } else if (context.methodName != null) {
@@ -176,11 +176,11 @@ private[core] object DefinitiASTParser {
     }
   }
 
-  private def processParenthesisExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processParenthesisExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     processExpression(context.parenthesis)
   }
 
-  private def processMethodCallExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processMethodCallExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     MethodCall(
       expression = processExpression(context.methodExpression),
       method = context.methodName.getText,
@@ -192,7 +192,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processAttributeCallExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processAttributeCallExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     AttributeCall(
       expression = processExpression(context.attributeExpression),
       attribute = context.attributeName.getText,
@@ -200,11 +200,11 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processNotExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processNotExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     Not(processExpression(context.notExpression), getRangeFromContext(context))
   }
 
-  private def processLeftRightExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processLeftRightExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     val left = processExpression(context.leftExpression)
     val right = processExpression(context.rightExpression)
     context.operator.getText match {
@@ -224,22 +224,22 @@ private[core] object DefinitiASTParser {
     }
   }
 
-  private def processBooleanExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processBooleanExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     context.booleanExpression.getText match {
       case "true" => BooleanValue(value = true, getRangeFromContext(context))
       case _ => BooleanValue(value = false, getRangeFromContext(context))
     }
   }
 
-  private def processNumberExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processNumberExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     NumberValue(BigDecimal(context.numberExpression.getText), getRangeFromContext(context))
   }
 
-  private def processStringExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processStringExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     QuotedStringValue(extractStringContent(context.stringExpression.getText), getRangeFromContext(context))
   }
 
-  private def processVariableExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processVariableExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     val variableName = context.variableExpression.getText
     scope.variables.find(variable => variable.name == variableName) match {
       case Some(variable) =>
@@ -253,7 +253,7 @@ private[core] object DefinitiASTParser {
     }
   }
 
-  private def processConditionExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processConditionExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     Condition(
       condition = processExpression(context.conditionExpression),
       onTrue = processChainedExpression(context.conditionIfBody),
@@ -262,7 +262,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processLambdaExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
+  def processLambdaExpression(context: ExpressionContext)(implicit scope: Scope): Expression = {
     val lambdaParameters = scalaSeq(context.parameterListDefinition().parameterDefinition()).map(processParameter)
     val outerVariableNotShadowed = scope.variables.filter(v => !lambdaParameters.exists(_.name == v.name))
     val innerVariables = parametersToVariables(lambdaParameters) ++ outerVariableNotShadowed
@@ -274,7 +274,7 @@ private[core] object DefinitiASTParser {
     )
   }
 
-  private def processGenericTypeList(context: GenericTypeListContext): Seq[TypeReference] = {
+  def processGenericTypeList(context: GenericTypeListContext): Seq[TypeReference] = {
     if (context != null) {
       scalaSeq(context.genericType()).map { genericTypeContext =>
         TypeReference(
@@ -287,19 +287,19 @@ private[core] object DefinitiASTParser {
     }
   }
 
-  private def processGenericTypeListDefinition(context: GenericTypeListContext) = {
+  def processGenericTypeListDefinition(context: GenericTypeListContext) = {
     Option(context)
       .map(genericTypes => scalaSeq(genericTypes.genericType()).map(_.getText))
       .getOrElse(Seq())
   }
 
-  private def extractPackageName(context: DefinitiContext): String = {
+  def extractPackageName(context: DefinitiContext): String = {
     Option(context.packageName())
       .map(packageNameContext => dottedIdentifierToIdentifier(packageNameContext.dottedIdentifier()))
       .getOrElse("")
   }
 
-  private def extractImports(context: DefinitiContext): Map[String, String] = {
+  def extractImports(context: DefinitiContext): Map[String, String] = {
     scalaSeq(context.imports())
       .view
       .map(importContext => dottedIdentifierToIdentifier(importContext.dottedIdentifier()))
@@ -307,7 +307,7 @@ private[core] object DefinitiASTParser {
       .toMap
   }
 
-  private def dottedIdentifierToIdentifier(context: DottedIdentifierContext): String = {
+  def dottedIdentifierToIdentifier(context: DottedIdentifierContext): String = {
     scalaSeq(context.IDENTIFIER()).map(_.getText).mkString(".")
   }
 }

--- a/src/main/scala/definiti/core/parser/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/parser/ProjectLinking.scala
@@ -39,15 +39,20 @@ private[core] object ProjectLinking {
   }
 
   private def extractTypeMappingFromFile(rootFile: RootFile): TypeMapping = {
+    val packageNamePrefix = if (rootFile.packageName.nonEmpty) {
+      rootFile.packageName + "."
+    } else {
+      ""
+    }
     val verificationTypeMapping = rootFile.verifications
       .view
       .map(_.name)
-      .map(name => name -> (rootFile.packageName + "." + name))
+      .map(name => name -> (packageNamePrefix + name))
       .toMap
     val classDefinitionTypeMapping = rootFile.classDefinitions
       .view
       .map(_.name)
-      .map(name => name -> (rootFile.packageName + "." + name))
+      .map(name => name -> (packageNamePrefix + name))
       .toMap
 
     verificationTypeMapping ++ classDefinitionTypeMapping

--- a/src/main/scala/definiti/core/utils/CollectionUtils.scala
+++ b/src/main/scala/definiti/core/utils/CollectionUtils.scala
@@ -13,4 +13,8 @@ private[core] object CollectionUtils {
     stream.forEach((a) => buffer.append(a))
     buffer
   }
+
+  def javaList[A](seq: Seq[A]): java.util.List[A] = {
+    new java.util.ArrayList[A](seq.asJava)
+  }
 }

--- a/src/test/scala/definiti/core/generators/Generators.scala
+++ b/src/test/scala/definiti/core/generators/Generators.scala
@@ -7,4 +7,26 @@ object Generators {
     numElems <- Gen.choose(min, max)
     elems <- Gen.listOfN(numElems, gen)
   } yield elems
+
+  def numberAsString: Gen[String] = Gen.oneOf(integerAsString, floatAsString)
+
+  def integerAsString: Gen[String] = Gen.nonEmptyListOf(Gen.numChar).map(_.mkString(""))
+
+  def floatAsString: Gen[String] = for {
+    integer <- integerAsString
+    decimals <- integerAsString
+  } yield {
+    integer + "." + decimals
+  }
+
+  def decreasingFrequency(min: Int, max: Int): Gen[Int] = {
+    val frequencies = for (index <- min to max) yield {
+      index -> Gen.const(max - index)
+    }
+    Gen.frequency(frequencies: _*)
+  }
+
+  def listDecreasingFrequencySize[A](min: Int, max: Int, gen: Gen[A]): Gen[List[A]] = {
+   decreasingFrequency(min, max).flatMap(numberOfElements => Gen.listOfN(numberOfElements, gen))
+  }
 }

--- a/src/test/scala/definiti/core/generators/antlr/AntlrGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/AntlrGenerator.scala
@@ -1,0 +1,51 @@
+package definiti.core.generators.antlr
+
+import definiti.core.generators.Generators
+import definiti.core.mock.antlr.{TerminalNodeMock, TokenMock}
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
+import org.antlr.v4.runtime.tree.TerminalNode
+import org.scalacheck.Gen
+
+object AntlrGenerator {
+  lazy val anyBooleanNode: Gen[TerminalNode] = genNode(anyBooleanToken)
+  lazy val anyBooleanToken: Gen[Token] = genToken(Gen.oneOf("true", "false"))
+
+  lazy val anyNumberNode: Gen[TerminalNode] = genNode(anyNumberToken)
+  lazy val anyNumberToken: Gen[Token] = genToken(Generators.numberAsString)
+
+  lazy val anyStringNode: Gen[TerminalNode] = genNode(anyStringToken)
+  lazy val anyStringToken: Gen[Token] = genToken(Gen.alphaNumStr.map('"' + _ + '"'))
+
+  lazy val anyIdentifierNode: Gen[TerminalNode] = genNode(anyIdentifierToken)
+  lazy val anyIdentifierToken: Gen[Token] = genToken(Gen.alphaNumStr)
+
+  lazy val anyBinaryOperatorNode: Gen[TerminalNode] = genNode(anyBinaryOperatorToken)
+  lazy val anyBinaryOperatorToken: Gen[Token] = genToken(Gen.oneOf("*", "/", "%", "+", "-", "==", "!=", "<", "<=", ">", ">=", "&&", "||"))
+
+  lazy val anyNotOperatorNode: Gen[TerminalNode] = genNode(anyNotOperatorToken)
+  lazy val anyNotOperatorToken: Gen[Token] = genToken(Gen.const("!"))
+
+  lazy val anyDocCommentNode: Gen[TerminalNode] = genNode(anyDocCommentToken)
+  lazy val anyDocCommentToken: Gen[Token] = genToken(Gen.alphaNumStr.map("/**" + _ + "*/"))
+
+  def genContext[A <: ParserRuleContext](gen: Gen[A]): Gen[A] = for {
+    element <- gen
+    startToken <- anyIdentifierToken
+    stopToken <- anyIdentifierToken
+  } yield {
+    element.start = startToken
+    element.stop = stopToken
+    element
+  }
+
+  private def genNode(genToken: Gen[Token]): Gen[TerminalNode] = genToken.map(TerminalNodeMock)
+
+  private def genToken(genText: Gen[String]): Gen[Token] = for {
+    text <- genText
+    line <- Gen.posNum[Int]
+    startIndex <- Gen.posNum[Int]
+    stopIndex <- Gen.posNum[Int]
+  } yield {
+    TokenMock(text, line, startIndex, stopIndex)
+  }
+}

--- a/src/test/scala/definiti/core/generators/antlr/DefinitiContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/DefinitiContextGenerator.scala
@@ -1,0 +1,55 @@
+package definiti.core.generators.antlr
+
+import definiti.core.mock.antlr._
+import definiti.core.parser.antlr.DefinitiParser._
+import org.scalacheck.Gen
+
+object DefinitiContextGenerator {
+  lazy val anyDefinitiContext: Gen[DefinitiContext] = for {
+    packageName <- Gen.option(anyPackageName)
+    importsContextSeq <- Gen.listOf(anyImportsContext)
+    toplevelContextSeq <- Gen.listOf(anyToplevelContext)
+  } yield {
+    DefinitiContextMock(
+      packageName,
+      importsContextSeq,
+      toplevelContextSeq
+    )
+  }
+
+  lazy val anyPackageName: Gen[PackageNameContext] = AntlrGenerator.genContext(for {
+    dottedIdentifierContext <- anyDottedIdentifierContext
+  } yield {
+    PackageNameContextMock(dottedIdentifierContext)
+  })
+
+  lazy val anyImportsContext: Gen[ImportsContext] = AntlrGenerator.genContext(for {
+    dottedIdentifierContext <- anyDottedIdentifierContext
+  } yield {
+    ImportsContextMock(dottedIdentifierContext)
+  })
+
+  lazy val anyDottedIdentifierContext: Gen[DottedIdentifierContext] = AntlrGenerator.genContext(for {
+    identifiers <- Gen.listOf(AntlrGenerator.anyIdentifierNode)
+  } yield {
+    DottedIdentifierContextMock(identifiers)
+  })
+
+  lazy val anyToplevelContext: Gen[ToplevelContext] = Gen.oneOf(
+    anyToplevelVerificationContext,
+    anyToplevelDefinedTypeContextMock,
+    anyToplevelAliasTypeContextMock
+  )
+
+  lazy val anyToplevelVerificationContext: Gen[ToplevelVerificationContextMock] = {
+    AntlrGenerator.genContext(VerificationContextGenerator.anyVerificationContext.map(ToplevelVerificationContextMock))
+  }
+
+  lazy val anyToplevelDefinedTypeContextMock: Gen[ToplevelDefinedTypeContextMock] = {
+    AntlrGenerator.genContext(TypeContextGenerator.anyDefinedTypeContext.map(ToplevelDefinedTypeContextMock))
+  }
+
+  lazy val anyToplevelAliasTypeContextMock: Gen[ToplevelAliasTypeContextMock] = {
+    AntlrGenerator.genContext(TypeContextGenerator.anyAliasTypeContext.map(ToplevelAliasTypeContextMock))
+  }
+}

--- a/src/test/scala/definiti/core/generators/antlr/ExpressionContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/ExpressionContextGenerator.scala
@@ -1,0 +1,165 @@
+package definiti.core.generators.antlr
+
+import definiti.core.generators.Generators
+import definiti.core.mock.antlr._
+import definiti.core.parser.antlr.DefinitiParser._
+import org.scalacheck.Gen
+
+object ExpressionContextGenerator {
+  lazy val anyChainedExpressionContext: Gen[ChainedExpressionContext] = AntlrGenerator.genContext(for {
+    numberOfExpressions <- Generators.decreasingFrequency(1, 10)
+    expressionContexts <- Gen.listOfN(numberOfExpressions, anyExpressionContext)
+  } yield {
+    ChainedExpressionContextMock(expressionContexts)
+  })
+
+  lazy val anyExpressionContext: Gen[ExpressionContext] = anyExpressionContext(5)
+
+  def anyExpressionContext(limit: Int): Gen[ExpressionContext] = {
+    // Protection for recursion
+    limit match {
+      case 0 =>
+        Gen.oneOf(
+          anyStringExpressionContext,
+          anyNumberExpressionContext,
+          anyBooleanExpressionContext
+          // For now, refuse variable expression because directly dependant of context
+          //anyVariableExpressionContext
+        )
+      case n =>
+        Gen.frequency(
+        100 -> anyStringExpressionContext,
+        100 -> anyNumberExpressionContext,
+        100 -> anyBooleanExpressionContext,
+        // For now, refuse variable expression because directly dependant of context
+        //100 -> anyVariableExpressionContext,
+        50 -> anyNotExpressionContext(n - 1),
+        20 -> anyParenthesisExpressionContext(n - 1),
+        12 -> anyAttributeCallExpressionContext(n - 1),
+        10 -> anyBinaryOperatorExpressionContext(n - 1),
+        10 -> anyMethodCallExpressionContext(n - 1),
+        5 -> anyConditionExpressionContext(n - 1)
+      )
+    }
+  }
+
+  def anyLambdaExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    parameterListDefinitionContext <- anyParameterListDefinitionContext(limit)
+    lambdaExpressionContext <- anyExpressionContext(limit)
+  } yield {
+    LambdaExpressionContextMock(
+      parameterListDefinitionContext,
+      lambdaExpressionContext
+    )
+  })
+
+  def anyParenthesisExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    parenthesisContext <- anyExpressionContext(limit)
+  } yield {
+    ParenthesisExpressionContextMock(parenthesisContext)
+  })
+
+  def anyMethodCallExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    methodExpressionContext <- anyExpressionContext(limit)
+    methodNameToken <- AntlrGenerator.anyIdentifierToken
+    genericTypeListContext <- GenericTypesContextGenerators.anyGenericTypeListContext
+    methodExpressionParametersContext <- anyExpressionListContext(limit)
+  } yield {
+    MethodCallExpressionContextMock(
+      methodExpressionContext,
+      methodNameToken,
+      genericTypeListContext,
+      methodExpressionParametersContext
+    )
+  })
+
+  def anyAttributeCallExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    attributeExpressionContext <- anyExpressionContext(limit)
+    attributeNameToken <- AntlrGenerator.anyIdentifierToken
+  } yield {
+    AttributeCallExpressionContextMock(
+      attributeExpressionContext,
+      attributeNameToken
+    )
+  })
+
+  def anyNotExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    notExpressionContext <- anyExpressionContext(limit)
+  } yield {
+    NotExpressionContextMock(notExpressionContext)
+  })
+
+  def anyBinaryOperatorExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    leftExpressionContext <- anyExpressionContext(limit)
+    operatorNode <- AntlrGenerator.anyBinaryOperatorToken
+    rightExpressionContext <- anyExpressionContext(limit)
+  } yield {
+    BinaryOperatorExpressionContextMock(
+      leftExpressionContext,
+      operatorNode,
+      rightExpressionContext
+    )
+  })
+
+  lazy val anyBooleanExpressionContext: Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    boolean <- AntlrGenerator.anyBooleanNode
+  } yield {
+    BooleanExpressionContextMock(boolean)
+  })
+
+  lazy val anyNumberExpressionContext: Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    number <- AntlrGenerator.anyNumberNode
+  } yield {
+    NumberExpressionContextMock(number)
+  })
+
+  lazy val anyStringExpressionContext: Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    string <- AntlrGenerator.anyStringNode
+  } yield {
+    StringExpressionContextMock(string)
+  })
+
+  lazy val anyVariableExpressionContext: Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    variable <- AntlrGenerator.anyIdentifierToken
+  } yield {
+    VariableExpressionContextMock(variable)
+  })
+
+  def anyConditionExpressionContext(limit: Int): Gen[ExpressionContext] = AntlrGenerator.genContext(for {
+    conditionExpressionContext <- anyExpressionContext(limit)
+    conditionIfBodyContext <- anyChainedExpressionContext
+    conditionElseBodyContext <- Gen.option(anyChainedExpressionContext)
+  } yield {
+    ConditionExpressionContextMock(
+      conditionExpressionContext,
+      conditionIfBodyContext,
+      conditionElseBodyContext
+    )
+  })
+
+  def anyParameterListDefinitionContext(limit: Int): Gen[ParameterListDefinitionContext] = AntlrGenerator.genContext(for {
+    parameterDefinitionContexts <- Generators.listDecreasingFrequencySize(0, 5, anyParameterDefinitionContext(limit))
+  } yield {
+    ParameterListDefinitionContextMock(parameterDefinitionContexts)
+  })
+
+  def anyParameterDefinitionContext(limit: Int): Gen[ParameterDefinitionContext] = AntlrGenerator.genContext(for {
+    parameterNameToken <- AntlrGenerator.anyIdentifierToken
+    parameterTypeToken <- AntlrGenerator.anyIdentifierToken
+    identifiers <- Generators.listDecreasingFrequencySize(0, 5, AntlrGenerator.anyIdentifierNode)
+    genericTypeListContexts <- GenericTypesContextGenerators.anyGenericTypeListContext
+  } yield {
+    ParameterDefinitionContextMock(
+      parameterNameToken,
+      parameterTypeToken,
+      identifiers,
+      genericTypeListContexts
+    )
+  })
+
+  def anyExpressionListContext(limit: Int): Gen[ExpressionListContext] = AntlrGenerator.genContext(for {
+    expressionContexts <- Generators.listDecreasingFrequencySize(0, 5, anyExpressionContext(limit))
+  } yield {
+    ExpressionListContextMock(expressionContexts)
+  })
+}

--- a/src/test/scala/definiti/core/generators/antlr/FunctionContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/FunctionContextGenerator.scala
@@ -1,0 +1,40 @@
+package definiti.core.generators.antlr
+
+import definiti.core.generators.Generators
+import definiti.core.mock.antlr.{FunctionContextMock, ParameterDefinitionContextMock, ParameterListDefinitionContextMock}
+import definiti.core.parser.antlr.DefinitiParser._
+import org.scalacheck.Gen
+
+object FunctionContextGenerator {
+  lazy val anyFunctionContext: Gen[FunctionContext] = AntlrGenerator.genContext(for {
+    parameterListDefinitionContext <- anyParameterListDefinitionContext
+    chainedExpressionContext <- ExpressionContextGenerator.anyChainedExpressionContext
+    genericTypeListContext <- GenericTypesContextGenerators.anyGenericTypeListContext
+  } yield {
+    FunctionContextMock(
+      parameterListDefinitionContext,
+      chainedExpressionContext,
+      genericTypeListContext
+    )
+  })
+
+  lazy val anyParameterListDefinitionContext: Gen[ParameterListDefinitionContext] = AntlrGenerator.genContext(for {
+    parameterDefinitionContexts <- Generators.listOfBoundedSize(0, 3, anyParameterDefinitionContexts)
+  } yield {
+    ParameterListDefinitionContextMock(parameterDefinitionContexts)
+  })
+
+  lazy val anyParameterDefinitionContexts: Gen[ParameterDefinitionContext] = AntlrGenerator.genContext(for {
+    parameterNameToken <- AntlrGenerator.anyIdentifierToken
+    parameterTypeToken <- AntlrGenerator.anyIdentifierToken
+    identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
+    genericTypeListContexts <- GenericTypesContextGenerators.anyGenericTypeListContext
+  } yield {
+    ParameterDefinitionContextMock(
+      parameterNameToken,
+      parameterTypeToken,
+      identifiers,
+      genericTypeListContexts
+    )
+  })
+}

--- a/src/test/scala/definiti/core/generators/antlr/GenericTypesContextGenerators.scala
+++ b/src/test/scala/definiti/core/generators/antlr/GenericTypesContextGenerators.scala
@@ -1,0 +1,31 @@
+package definiti.core.generators.antlr
+
+import definiti.core.generators.Generators
+import definiti.core.mock.antlr.{GenericTypeContextMock, GenericTypeListContextMock}
+import definiti.core.parser.antlr.DefinitiParser._
+import org.scalacheck.Gen
+
+object GenericTypesContextGenerators {
+  lazy val anyGenericTypeListContext: Gen[GenericTypeListContext] = anyGenericTypeListContext(3)
+
+  lazy val anyGenericTypesContext: Gen[GenericTypeContext] = anyGenericTypesContext(3)
+
+  private def anyGenericTypeListContext(limit: Int): Gen[GenericTypeListContext] = AntlrGenerator.genContext(for {
+    genericTypeContexts <- Generators.listOfBoundedSize(0, 3, anyGenericTypesContext(limit - 1))
+  } yield {
+    GenericTypeListContextMock(genericTypeContexts)
+  })
+
+  private def anyGenericTypesContext(limit: Int): Gen[GenericTypeContext] = {
+    val genericTypeListContextGenerator = limit match {
+      case 0 => Gen.const(None)
+      case n => Gen.option(anyGenericTypeListContext(n - 1))
+    }
+    AntlrGenerator.genContext(for {
+      identifier <- AntlrGenerator.anyIdentifierNode
+      genericTypeListContext <- genericTypeListContextGenerator
+    } yield {
+      GenericTypeContextMock(identifier, genericTypeListContext)
+    })
+  }
+}

--- a/src/test/scala/definiti/core/generators/antlr/TypeContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/TypeContextGenerator.scala
@@ -1,0 +1,104 @@
+package definiti.core.generators.antlr
+
+import definiti.core.generators.Generators
+import definiti.core.mock.antlr._
+import definiti.core.parser.antlr.DefinitiParser.{TypeVerificationFunctionContext, _}
+import org.scalacheck.Gen
+
+object TypeContextGenerator {
+  lazy val anyDefinedTypeContext: Gen[DefinedTypeContext] = AntlrGenerator.genContext(for {
+    typeNameToken <- AntlrGenerator.anyIdentifierToken
+    identifier <- AntlrGenerator.anyIdentifierNode
+    docComment <- Gen.option(AntlrGenerator.anyDocCommentNode)
+    inheritances <- Generators.listOfBoundedSize(0, 3, anyInheritanceContext)
+    genericTypeListContext <- Gen.option(GenericTypesContextGenerators.anyGenericTypeListContext)
+    attributeDefinitionContexts <- Generators.listOfBoundedSize(0, 3, anyAttributeDefinitionContext)
+    typeVerificationContexts <- Generators.listOfBoundedSize(0, 3, anyTypeVerificationContext)
+  } yield {
+    DefinedTypeContextMock(
+      typeNameToken,
+      identifier,
+      docComment,
+      inheritances,
+      genericTypeListContext,
+      attributeDefinitionContexts,
+      typeVerificationContexts
+    )
+  })
+
+  lazy val anyAliasTypeContext: Gen[AliasTypeContext] = AntlrGenerator.genContext(for {
+    typeNameToken <- AntlrGenerator.anyIdentifierToken
+    genericTypesContext <- Gen.option(GenericTypesContextGenerators.anyGenericTypeListContext)
+    referenceTypeNameToken <- AntlrGenerator.anyIdentifierToken
+    aliasGenericTypesContext <- Gen.option(GenericTypesContextGenerators.anyGenericTypeListContext)
+    identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
+    docComment <- Gen.option(AntlrGenerator.anyDocCommentNode)
+    inheritances <- Generators.listOfBoundedSize(0, 3, anyInheritanceContext)
+  } yield {
+    AliasTypeContextMock(
+      typeNameToken,
+      genericTypesContext,
+      referenceTypeNameToken,
+      aliasGenericTypesContext,
+      identifiers,
+      docComment,
+      inheritances
+    )
+  })
+
+  lazy val anyInheritanceContext: Gen[InheritanceContext] = AntlrGenerator.genContext(for {
+    verificationNameToken <- AntlrGenerator.anyIdentifierToken
+    identifier <- AntlrGenerator.anyIdentifierNode
+  } yield {
+    InheritanceContextMock(
+      verificationNameToken,
+      identifier
+    )
+  })
+
+  lazy val anyAttributeDefinitionContext: Gen[AttributeDefinitionContext] = AntlrGenerator.genContext(for {
+    attributeNameToken <- AntlrGenerator.anyIdentifierToken
+    attributeTypeToken <- AntlrGenerator.anyIdentifierToken
+    attributeVerificationsContext <- anyAttributeVerificationContext
+    identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
+    docComment <- Gen.option(AntlrGenerator.anyDocCommentNode)
+    genericTypeListContext <- GenericTypesContextGenerators.anyGenericTypeListContext
+  } yield {
+    AttributeDefinitionContextMock(
+      attributeNameToken,
+      attributeTypeToken,
+      attributeVerificationsContext,
+      identifiers,
+      docComment,
+      genericTypeListContext
+    )
+  })
+
+  lazy val anyTypeVerificationContext: Gen[TypeVerificationContext] = AntlrGenerator.genContext(for {
+    verificationMessageToken <- AntlrGenerator.anyStringToken
+    typeVerificationFunctionContext <- anyTypeVerificationFunctionContext
+    string <- AntlrGenerator.anyStringNode
+  } yield {
+    TypeVerificationContextMock(
+      verificationMessageToken,
+      typeVerificationFunctionContext,
+      string
+    )
+  })
+
+  lazy val anyAttributeVerificationContext: Gen[AttributeVerificationsContext] = AntlrGenerator.genContext(for {
+    identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
+  } yield {
+    AttributeVerificationsContextMock(identifiers)
+  })
+
+  lazy val anyTypeVerificationFunctionContext: Gen[TypeVerificationFunctionContext] = AntlrGenerator.genContext(for {
+    identifier <- AntlrGenerator.anyIdentifierNode
+    chainedExpressionContext <- ExpressionContextGenerator.anyChainedExpressionContext
+  } yield {
+    TypeVerificationFunctionContextMock(
+      identifier,
+      chainedExpressionContext
+    )
+  })
+}

--- a/src/test/scala/definiti/core/generators/antlr/VerificationContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/VerificationContextGenerator.scala
@@ -1,0 +1,25 @@
+package definiti.core.generators.antlr
+
+import definiti.core.mock.antlr.VerificationContextMock
+import definiti.core.parser.antlr.DefinitiParser.VerificationContext
+import org.scalacheck.Gen
+
+object VerificationContextGenerator {
+  lazy val anyVerificationContext: Gen[VerificationContext] = AntlrGenerator.genContext(for {
+    verificationNameToken <- AntlrGenerator.anyIdentifierToken
+    verificationMessageToken <- AntlrGenerator.anyStringToken
+    functionContext <- FunctionContextGenerator.anyFunctionContext
+    identifier <- AntlrGenerator.anyIdentifierNode
+    string <- AntlrGenerator.anyStringNode
+    docComment <- AntlrGenerator.anyDocCommentNode
+  } yield {
+    VerificationContextMock(
+      verificationNameToken,
+      verificationMessageToken,
+      functionContext,
+      identifier,
+      string,
+      docComment
+    )
+  })
+}

--- a/src/test/scala/definiti/core/mock/antlr/AntlrMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/AntlrMock.scala
@@ -1,0 +1,56 @@
+package definiti.core.mock.antlr
+
+import org.antlr.v4.runtime.misc.Interval
+import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.tree.{ParseTree, ParseTreeVisitor, TerminalNode}
+
+case class TerminalNodeMock(token: Token) extends TerminalNode {
+  override def getSymbol: Token = token
+
+  override def getText: String = token.getText
+
+  override def setParent(parent: RuleContext): Unit = ???
+
+  override def toStringTree(parser: Parser): String = ???
+
+  override def getParent: ParseTree = ???
+
+  override def getChild(i: Int): ParseTree = ???
+
+  override def accept[T](visitor: ParseTreeVisitor[_ <: T]): T = ???
+
+  override def getSourceInterval: Interval = ???
+
+  override def toStringTree: String = ???
+
+  override def getChildCount: Int = ???
+
+  override def getPayload: AnyRef = ???
+}
+
+case class TokenMock(
+  text: String,
+  line: Int,
+  startIndex: Int,
+  stopIndex: Int
+) extends Token {
+  override def getText: String = text
+
+  override def getLine: Int = line
+
+  override def getCharPositionInLine: Int = startIndex
+
+  override def getStartIndex: Int = startIndex
+
+  override def getStopIndex: Int = stopIndex
+
+  override def getChannel: Int = ???
+
+  override def getTokenIndex: Int = ???
+
+  override def getTokenSource: TokenSource = ???
+
+  override def getInputStream: CharStream = ???
+
+  override def getType: Int = ???
+}

--- a/src/test/scala/definiti/core/mock/antlr/DefinitiContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/DefinitiContextMock.scala
@@ -1,0 +1,69 @@
+package definiti.core.mock.antlr
+
+import java.util.{List => JList}
+
+import definiti.core.parser.antlr.DefinitiParser._
+import definiti.core.utils.CollectionUtils._
+import org.antlr.v4.runtime.tree.TerminalNode
+
+case class DefinitiContextMock(
+  packageNameContext: Option[PackageNameContext],
+  importsContextSeq: Seq[ImportsContext],
+  toplevelContextSeq: Seq[ToplevelContext]
+) extends DefinitiContext(null, 0) {
+  override def packageName: PackageNameContext = packageNameContext.orNull
+
+  override def imports: JList[ImportsContext] = javaList(importsContextSeq)
+
+  override def imports(i: Int): ImportsContext = importsContextSeq(i)
+
+  override def toplevel: JList[ToplevelContext] = javaList(toplevelContextSeq)
+
+  override def toplevel(i: Int): ToplevelContext = toplevelContextSeq(i)
+}
+
+case class PackageNameContextMock(
+  dottedIdentifierContext: DottedIdentifierContext
+) extends PackageNameContext(null, 0) {
+  override def dottedIdentifier: DottedIdentifierContext = dottedIdentifierContext
+}
+
+case class ImportsContextMock(
+  dottedIdentifierContext: DottedIdentifierContext
+) extends ImportsContext(null, 0) {
+  override def dottedIdentifier: DottedIdentifierContext = dottedIdentifierContext
+}
+
+case class DottedIdentifierContextMock(
+  identifiers: Seq[TerminalNode]
+) extends DottedIdentifierContext(null, 0) {
+  override def IDENTIFIER: JList[TerminalNode] = javaList(identifiers)
+
+  override def IDENTIFIER(i: Int): TerminalNode = identifiers(i)
+}
+
+abstract class ToplevelContextMock extends ToplevelContext(null, 0) {
+  override def verification(): VerificationContext = null
+
+  override def definedType(): DefinedTypeContext = null
+
+  override def aliasType(): AliasTypeContext = null
+}
+
+case class ToplevelVerificationContextMock(
+  verificationContext: VerificationContext
+) extends ToplevelContextMock {
+  override def verification(): VerificationContext = verificationContext
+}
+
+case class ToplevelDefinedTypeContextMock(
+  definedTypeContext: DefinedTypeContext
+) extends ToplevelContextMock {
+  override def definedType(): DefinedTypeContext = definedTypeContext
+}
+
+case class ToplevelAliasTypeContextMock(
+  aliasTypeContext: AliasTypeContext
+) extends ToplevelContextMock {
+  override def aliasType(): AliasTypeContext = aliasTypeContext
+}

--- a/src/test/scala/definiti/core/mock/antlr/ExpressionContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/ExpressionContextMock.scala
@@ -1,0 +1,167 @@
+package definiti.core.mock.antlr
+
+import java.util.{List => JList}
+
+import definiti.core.parser.antlr.DefinitiParser._
+import definiti.core.utils.CollectionUtils._
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.tree.TerminalNode
+
+case class ChainedExpressionContextMock(
+  expressionContexts: Seq[ExpressionContext]
+) extends ChainedExpressionContext(null, 0) {
+  override def expression(): JList[ExpressionContext] = javaList(expressionContexts)
+
+  override def expression(i: Int): ExpressionContext = expressionContexts(i)
+}
+
+abstract class ExpressionContextMock extends ExpressionContext(null, 0) {
+  this.methodExpression = null
+  this.attributeExpression = null
+  this.leftExpression = null
+  this.lambdaExpression = null
+  this.parenthesis = null
+  this.notExpression = null
+  this.booleanExpression = null
+  this.numberExpression = null
+  this.stringExpression = null
+  this.variableExpression = null
+  this.conditionExpression = null
+  this.conditionIfBody = null
+  this.conditionElseBody = null
+  this.operator = null
+  this.rightExpression = null
+  this.methodName = null
+  this.methodExpressionParameters = null
+  this.attributeName = null
+
+  override def parameterListDefinition(): ParameterListDefinitionContext = null
+
+  override def expression(): JList[ExpressionContext] = javaList(Seq())
+
+  override def expression(i: Int): ExpressionContext = null
+
+  override def BOOLEAN(): TerminalNode = null
+
+  override def NUMBER(): TerminalNode = null
+
+  override def STRING(): TerminalNode = null
+
+  override def IDENTIFIER(): TerminalNode = null
+
+  override def chainedExpression(): JList[ChainedExpressionContext] = javaList(Seq())
+
+  override def chainedExpression(i: Int): ChainedExpressionContext = null
+
+  override def CALCULATOR_OPERATOR_LEVEL_1(): TerminalNode = null
+
+  override def CALCULATOR_OPERATOR_LEVEL_2(): TerminalNode = null
+
+  override def LOGICAL_OPERATOR(): TerminalNode = null
+
+  override def LOGICAL_COMBINATION_OPERATOR(): TerminalNode = null
+
+  override def genericTypeList(): GenericTypeListContext = null
+
+  override def expressionList(): ExpressionListContext = null
+}
+
+case class LambdaExpressionContextMock(
+  parameterListDefinitionContext: ParameterListDefinitionContext,
+  lambdaExpressionContext: ExpressionContext
+) extends ExpressionContextMock {
+  this.lambdaExpression = lambdaExpressionContext
+
+  override def parameterListDefinition(): ParameterListDefinitionContext = parameterListDefinitionContext
+}
+
+case class ParenthesisExpressionContextMock(
+  parenthesisContext: ExpressionContext
+) extends ExpressionContextMock {
+  this.parenthesis = parenthesisContext
+}
+
+case class MethodCallExpressionContextMock(
+  methodExpressionContext: ExpressionContext,
+  methodNameToken: Token,
+  genericTypeListContext: GenericTypeListContext,
+  methodExpressionParametersContext: ExpressionListContext
+) extends ExpressionContextMock {
+  this.methodExpression = methodExpressionContext
+  this.methodName = methodNameToken
+  this.methodExpressionParameters = methodExpressionParametersContext
+
+  override def genericTypeList(): GenericTypeListContext = genericTypeListContext
+}
+
+case class AttributeCallExpressionContextMock(
+  attributeExpressionContext: ExpressionContext,
+  attributeNameToken: Token
+) extends ExpressionContextMock {
+  this.attributeExpression = attributeExpressionContext
+  this.attributeName = attributeNameToken
+}
+
+case class NotExpressionContextMock(
+  notExpressionContext: ExpressionContext
+) extends ExpressionContextMock {
+  this.notExpression = notExpressionContext
+}
+
+case class BinaryOperatorExpressionContextMock(
+  leftExpressionContext: ExpressionContext,
+  operatorNode: Token,
+  rightExpressionContext: ExpressionContext
+) extends ExpressionContextMock {
+  this.leftExpression = leftExpressionContext
+  this.operator = operatorNode
+  this.rightExpression = rightExpressionContext
+}
+
+case class BooleanExpressionContextMock(
+  boolean: TerminalNode
+) extends ExpressionContextMock {
+  this.booleanExpression = boolean.getSymbol
+
+  override def BOOLEAN(): TerminalNode = boolean
+}
+
+case class NumberExpressionContextMock(
+  number: TerminalNode
+) extends ExpressionContextMock {
+  this.numberExpression = number.getSymbol
+
+  override def NUMBER(): TerminalNode = number
+}
+
+case class StringExpressionContextMock(
+  string: TerminalNode
+) extends ExpressionContextMock {
+  this.stringExpression = string.getSymbol
+
+  override def STRING(): TerminalNode = string
+}
+
+case class VariableExpressionContextMock(
+  variable: Token
+) extends ExpressionContextMock {
+  this.variableExpression = variable
+}
+
+case class ConditionExpressionContextMock(
+  conditionExpressionContext: ExpressionContext,
+  conditionIfBodyContext: ChainedExpressionContext,
+  conditionElseBodyContext: Option[ChainedExpressionContext]
+) extends ExpressionContextMock {
+  this.conditionExpression = conditionExpressionContext
+  this.conditionIfBody = conditionIfBodyContext
+  this.conditionElseBody = conditionElseBodyContext.orNull
+}
+
+case class ExpressionListContextMock(
+  expressionContexts: Seq[ExpressionContext]
+) extends ExpressionListContext(null, 0) {
+  override def expression(): JList[ExpressionContext] = javaList(expressionContexts)
+
+  override def expression(i: Int): ExpressionContext = expressionContexts(i)
+}

--- a/src/test/scala/definiti/core/mock/antlr/FunctionContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/FunctionContextMock.scala
@@ -1,0 +1,44 @@
+package definiti.core.mock.antlr
+
+import java.util.{List => JList}
+
+import definiti.core.parser.antlr.DefinitiParser._
+import definiti.core.utils.CollectionUtils._
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.tree.TerminalNode
+
+case class FunctionContextMock(
+  parameterListDefinitionContext: ParameterListDefinitionContext,
+  chainedExpressionContext: ChainedExpressionContext,
+  genericTypeListContext: GenericTypeListContext
+) extends FunctionContext(null, 0) {
+  override def parameterListDefinition(): ParameterListDefinitionContext = parameterListDefinitionContext
+
+  override def chainedExpression(): ChainedExpressionContext = chainedExpressionContext
+
+  override def genericTypeList(): GenericTypeListContext = genericTypeListContext
+}
+
+case class ParameterListDefinitionContextMock(
+  parameterDefinitionContexts: Seq[ParameterDefinitionContext]
+) extends ParameterListDefinitionContext(null, 0) {
+  override def parameterDefinition(): JList[ParameterDefinitionContext] = javaList(parameterDefinitionContexts)
+
+  override def parameterDefinition(i: Int): ParameterDefinitionContext = parameterDefinitionContexts(i)
+}
+
+case class ParameterDefinitionContextMock(
+  parameterNameToken: Token,
+  parameterTypeToken: Token,
+  identifiers: Seq[TerminalNode],
+  genericTypeListContexts: GenericTypeListContext
+) extends ParameterDefinitionContext(null, 0) {
+  this.parameterName = parameterNameToken
+  this.parameterType = parameterTypeToken
+
+  override def IDENTIFIER(): JList[TerminalNode] = javaList(identifiers)
+
+  override def IDENTIFIER(i: Int): TerminalNode = identifiers(i)
+
+  override def genericTypeList(): GenericTypeListContext = genericTypeListContexts
+}

--- a/src/test/scala/definiti/core/mock/antlr/GenericTypesContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/GenericTypesContextMock.scala
@@ -1,0 +1,24 @@
+package definiti.core.mock.antlr
+
+import java.util.{List => JList}
+
+import definiti.core.parser.antlr.DefinitiParser._
+import definiti.core.utils.CollectionUtils.javaList
+import org.antlr.v4.runtime.tree.TerminalNode
+
+case class GenericTypeListContextMock(
+  genericTypeContexts: Seq[GenericTypeContext]
+) extends GenericTypeListContext(null, 0) {
+  override def genericType(): JList[GenericTypeContext] = javaList(genericTypeContexts)
+
+  override def genericType(i: Int): GenericTypeContext = genericTypeContexts(i)
+}
+
+case class GenericTypeContextMock(
+  identifier: TerminalNode,
+  genericTypeListContext: Option[GenericTypeListContext]
+) extends GenericTypeContext(null, 0) {
+  override def IDENTIFIER(): TerminalNode = identifier
+
+  override def genericTypeList(): GenericTypeListContext = genericTypeListContext.orNull
+}

--- a/src/test/scala/definiti/core/mock/antlr/TypeContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/TypeContextMock.scala
@@ -1,0 +1,127 @@
+package definiti.core.mock.antlr
+
+import java.util.{List => JList}
+
+import definiti.core.parser.antlr.DefinitiParser._
+import definiti.core.utils.CollectionUtils._
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.tree.TerminalNode
+
+case class AliasTypeContextMock(
+  typeNameToken: Token,
+  genericTypesContext: Option[GenericTypeListContext],
+  referenceTypeNameToken: Token,
+  aliasGenericTypesContext: Option[GenericTypeListContext],
+  identifiers: Seq[TerminalNode],
+  docComment: Option[TerminalNode],
+  inheritances: Seq[InheritanceContext]
+) extends AliasTypeContext(null, 0) {
+  this.typeName = typeNameToken
+  this.genericTypes = genericTypesContext.orNull
+  this.referenceTypeName = referenceTypeNameToken
+  this.aliasGenericTypes = aliasGenericTypesContext.orNull
+
+  override def IDENTIFIER(): JList[TerminalNode] = javaList(identifiers)
+
+  override def IDENTIFIER(i: Int): TerminalNode = identifiers(i)
+
+  override def DOC_COMMENT(): TerminalNode = docComment.orNull
+
+  override def inheritance(): JList[InheritanceContext] = javaList(inheritances)
+
+  override def inheritance(i: Int): InheritanceContext = inheritances(i)
+
+  override def genericTypeList(): JList[GenericTypeListContext] = javaList(Seq(genericTypes, aliasGenericTypes))
+
+  override def genericTypeList(i: Int): GenericTypeListContext = genericTypeList().get(i)
+}
+
+case class DefinedTypeContextMock(
+  typeNameToken: Token,
+  identifier: TerminalNode,
+  docComment: Option[TerminalNode],
+  inheritances: Seq[InheritanceContext],
+  genericTypeListContext: Option[GenericTypeListContext],
+  attributeDefinitionContexts: Seq[AttributeDefinitionContext],
+  typeVerificationContexts: Seq[TypeVerificationContext]
+) extends DefinedTypeContext(null, 0) {
+  this.typeName = typeNameToken
+
+  override def IDENTIFIER(): TerminalNode = identifier
+
+  override def DOC_COMMENT(): TerminalNode = docComment.orNull
+
+  override def inheritance(): JList[InheritanceContext] = javaList(inheritances)
+
+  override def inheritance(i: Int): InheritanceContext = inheritances(i)
+
+  override def genericTypeList(): GenericTypeListContext = genericTypeListContext.orNull
+
+  override def attributeDefinition(): JList[AttributeDefinitionContext] = javaList(attributeDefinitionContexts)
+
+  override def attributeDefinition(i: Int): AttributeDefinitionContext = attributeDefinitionContexts(i)
+
+  override def typeVerification(): JList[TypeVerificationContext] = javaList(typeVerificationContexts)
+
+  override def typeVerification(i: Int): TypeVerificationContext = typeVerificationContexts(i)
+}
+
+case class InheritanceContextMock(
+  verificationNameToken: Token,
+  identifier: TerminalNode
+) extends InheritanceContext(null, 0) {
+  this.verificationName = verificationNameToken
+
+  override def IDENTIFIER(): TerminalNode = identifier
+}
+
+case class AttributeDefinitionContextMock(
+  attributeNameToken: Token,
+  attributeTypeToken: Token,
+  attributeVerificationsContext: AttributeVerificationsContext,
+  identifiers: Seq[TerminalNode],
+  docComment: Option[TerminalNode],
+  genericTypeListContext: GenericTypeListContext
+) extends AttributeDefinitionContext(null, 0) {
+  this.attributeName = attributeNameToken
+  this.attributeType = attributeTypeToken
+
+  override def attributeVerifications(): AttributeVerificationsContext = attributeVerificationsContext
+
+  override def IDENTIFIER(): JList[TerminalNode] = javaList(identifiers)
+
+  override def IDENTIFIER(i: Int): TerminalNode = identifiers(i)
+
+  override def DOC_COMMENT(): TerminalNode = docComment.orNull
+
+  override def genericTypeList(): GenericTypeListContext = genericTypeListContext
+}
+
+case class AttributeVerificationsContextMock(
+  identifiers: Seq[TerminalNode]
+) extends AttributeVerificationsContext(null, 0) {
+  override def IDENTIFIER(): JList[TerminalNode] = javaList(identifiers)
+
+  override def IDENTIFIER(i: Int): TerminalNode = identifiers(i)
+}
+
+case class TypeVerificationContextMock(
+  verificationMessageToken: Token,
+  typeVerificationFunctionContext: TypeVerificationFunctionContext,
+  string: TerminalNode
+) extends TypeVerificationContext(null, 0) {
+  this.verificationMessage = verificationMessageToken
+
+  override def typeVerificationFunction(): TypeVerificationFunctionContext = typeVerificationFunctionContext
+
+  override def STRING(): TerminalNode = string
+}
+
+case class TypeVerificationFunctionContextMock(
+  identifier: TerminalNode,
+  chainedExpressionContext: ChainedExpressionContext
+) extends TypeVerificationFunctionContext(null, 0) {
+  override def IDENTIFIER(): TerminalNode = identifier
+
+  override def chainedExpression(): ChainedExpressionContext = chainedExpressionContext
+}

--- a/src/test/scala/definiti/core/mock/antlr/VerificationContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/VerificationContextMock.scala
@@ -1,0 +1,26 @@
+package definiti.core.mock.antlr
+
+import definiti.core.parser.antlr.DefinitiParser._
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.tree.TerminalNode
+
+case class VerificationContextMock(
+  verificationNameToken: Token,
+  verificationMessageToken: Token,
+  functionContext: FunctionContext,
+  identifier: TerminalNode,
+  string: TerminalNode,
+  docComment: TerminalNode
+) extends VerificationContext(null, 0) {
+  this.verificationName = verificationNameToken
+
+  this.verificationMessage = verificationMessageToken
+
+  override def function(): FunctionContext = functionContext
+
+  override def IDENTIFIER(): TerminalNode = identifier
+
+  override def STRING(): TerminalNode = string
+
+  override def DOC_COMMENT(): TerminalNode = docComment
+}

--- a/src/test/scala/definiti/core/parser/DefinitiASTParserProcessDefinedTypeSpec.scala
+++ b/src/test/scala/definiti/core/parser/DefinitiASTParserProcessDefinedTypeSpec.scala
@@ -1,0 +1,20 @@
+package definiti.core.parser
+
+import definiti.core.generators.antlr.TypeContextGenerator
+import definiti.core.TypeReference
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
+
+class DefinitiASTParserProcessDefinedTypeSpec extends FlatSpec with Matchers with PropertyChecks {
+  "DefinitiASTParser.processDefinedType" should "have only TypeVerification with DefinedTypeName" in {
+    forAll(TypeContextGenerator.anyDefinedTypeContext) { definedTypeContext =>
+      val result = DefinitiASTParser.processDefinedType(definedTypeContext)
+
+      Inspectors.forAll(result.verifications.toList) { verification =>
+        verification.function.parameters should have length 1
+        verification.function.parameters.head.typeReference should be(a[TypeReference])
+        verification.function.parameters.head.typeReference.asInstanceOf[TypeReference].typeName should be(result.name)
+      }
+    }
+  }
+}

--- a/src/test/scala/definiti/core/parser/DefinitiASTParserProcessTypeVerificationSpec.scala
+++ b/src/test/scala/definiti/core/parser/DefinitiASTParserProcessTypeVerificationSpec.scala
@@ -1,0 +1,23 @@
+package definiti.core.parser
+
+import definiti.core.TypeReference
+import definiti.core.generators.antlr.TypeContextGenerator
+import org.scalacheck.Gen
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.PropertyChecks
+
+class DefinitiASTParserProcessTypeVerificationSpec extends FlatSpec with Matchers with PropertyChecks {
+  "DefinitiASTParser.processTypeVerification" should "returns a TypeVerification with a function of one parameter of given type" in {
+    val cases = for {
+      typeVerificationContext <- TypeContextGenerator.anyTypeVerificationContext
+      typeName <- Gen.alphaNumStr
+    } yield (typeVerificationContext, typeName)
+
+    forAll(cases) { case (typeVerificationContext, typeName) =>
+      val result = DefinitiASTParser.processTypeVerification(typeVerificationContext, typeName)
+      result.function.parameters should have length 1
+      result.function.parameters.head.typeReference should be (a[TypeReference])
+      result.function.parameters.head.typeReference.asInstanceOf[TypeReference].typeName should be (typeName)
+    }
+  }
+}


### PR DESCRIPTION
* Because in `type`/`verify` block, the only accepted parameter is a parameter of outer Type, accept only one parameter without type
* Update antlr definition file
* Adapts parser to accept new antlr model
* Correct `first.def` accepting new syntax
* Also correct type and verification canonical names and injections in case there is no package name at the beginning of the file
* Create mocks for Antlr objects
* Create PBT generators for Antlr objects
* Remove visibility of `DefinitiASTParser` methods (object visible in `definiti.core`)
* Verify `processTypeVerification` and `processDefinedType` about parameters definition
* This PR resolves #15