### PR TITLE
[#11] When referencing a `Verification`, it is now possible to override its message

### DIFF
--- a/src/main/antlr/Definiti.g4
+++ b/src/main/antlr/Definiti.g4
@@ -59,7 +59,7 @@ verification :
 
 definedType :
   DOC_COMMENT?
-  'type' typeName=IDENTIFIER inheritance* ('[' genericTypeList ']')? '{'
+  'type' typeName=IDENTIFIER ('[' genericTypeList ']')? verifyingList '{'
     attributeDefinition+
 
     (typeVerification)*
@@ -67,9 +67,7 @@ definedType :
 
 attributeDefinition:
   DOC_COMMENT?
-  attributeName=IDENTIFIER ':' attributeType=IDENTIFIER ('[' genericTypeList ']')? attributeVerifications;
-
-attributeVerifications: ('verifying' IDENTIFIER)*;
+  attributeName=IDENTIFIER ':' attributeType=IDENTIFIER ('[' genericTypeList ']')? verifyingList;
 
 typeVerification:
   'verify' '{'
@@ -81,11 +79,12 @@ typeVerificationFunction: '(' IDENTIFIER ')' '=>' '{' chainedExpression '}';
 
 aliasType :
   DOC_COMMENT?
-  'type' typeName=IDENTIFIER ('[' genericTypes=genericTypeList ']')? '=' referenceTypeName=IDENTIFIER ('[' aliasGenericTypes=genericTypeList ']')? inheritance*;
+  'type' typeName=IDENTIFIER ('[' genericTypes=genericTypeList ']')? '=' referenceTypeName=IDENTIFIER ('[' aliasGenericTypes=genericTypeList ']')? verifyingList;
 
 function : ('[' genericTypeList ']')? '(' parameterListDefinition ')' '=>' '{' chainedExpression '}';
 
-inheritance : ('verifying' verificationName=IDENTIFIER);
+verifyingList : verifying*;
+verifying : 'verifying' verificationName=IDENTIFIER ('(' message=STRING ')')?;
 
 parameterDefinition: parameterName=IDENTIFIER ':' parameterType=IDENTIFIER ('[' genericTypeList ']')?;
 parameterListDefinition: ((parameterDefinition ',')* parameterDefinition | );

--- a/src/main/resources/samples/src2/person.def
+++ b/src/main/resources/samples/src2/person.def
@@ -5,7 +5,13 @@ import my.verifications.NonBlank
 import my.verifications.PhoneNumber
 
 type Person {
-  firstName: String verifying NonEmptyString
-  lastName: String verifying NonEmptyString
-  telephone: String verifying NonBlank verifying PhoneNumber
+  firstName: String verifying NonEmptyString("Please provide a first name")
+  lastName: String verifying NonEmptyString("Please provide a last name")
+  telephone: String
+    verifying NonBlank("Please provide a phone number")
+    verifying PhoneNumber
 }
+
+type RequiredString = String verifying NonEmptyString
+
+type RequiredNoun = String verifying NonEmptyString("This noun must be defined")

--- a/src/main/resources/samples/src2/verifications.def
+++ b/src/main/resources/samples/src2/verifications.def
@@ -15,7 +15,7 @@ verification NonBlank {
 }
 
 verification PhoneNumber {
-  "Please provide a phone number"
+  "Please provide a valid phone number"
   (string: String) => {
     if (string.nonEmpty()) {
       if (string.startsWith("+33")) {

--- a/src/main/scala/definiti/core/AST.scala
+++ b/src/main/scala/definiti/core/AST.scala
@@ -45,7 +45,7 @@ case class AttributeDefinition(
   name: String,
   typeReference: TypeReference,
   comment: Option[String],
-  verifications: Seq[String],
+  verifications: Seq[VerificationReference],
   range: Range
 )
 
@@ -181,7 +181,7 @@ sealed trait Type extends ClassDefinition {
   def comment: Option[String]
 }
 
-case class DefinedType(name: String, packageName: String, genericTypes: Seq[String], attributes: Seq[AttributeDefinition], verifications: Seq[TypeVerification], inherited: Seq[String], comment: Option[String], range: Range) extends Type {
+case class DefinedType(name: String, packageName: String, genericTypes: Seq[String], attributes: Seq[AttributeDefinition], verifications: Seq[TypeVerification], inherited: Seq[VerificationReference], comment: Option[String], range: Range) extends Type {
   def methods: Seq[MethodDefinition] = Seq()
 
   override def canonicalName: String = {
@@ -193,7 +193,7 @@ case class DefinedType(name: String, packageName: String, genericTypes: Seq[Stri
   }
 }
 
-case class AliasType(name: String, packageName: String, genericTypes: Seq[String], alias: TypeReference, inherited: Seq[String], comment: Option[String], range: Range) extends Type {
+case class AliasType(name: String, packageName: String, genericTypes: Seq[String], alias: TypeReference, inherited: Seq[VerificationReference], comment: Option[String], range: Range) extends Type {
   override def canonicalName: String = {
     if (packageName.nonEmpty) {
       packageName + "." + name
@@ -204,3 +204,5 @@ case class AliasType(name: String, packageName: String, genericTypes: Seq[String
 }
 
 case class TypeVerification(message: String, function: DefinedFunction, range: Range)
+
+case class VerificationReference(verificationName: String, message: Option[String], range: Range)

--- a/src/main/scala/definiti/core/Context.scala
+++ b/src/main/scala/definiti/core/Context.scala
@@ -7,7 +7,15 @@ sealed trait Context {
 
   def isVerificationAvailable(verificationName: String): Boolean
 
+  def isVerificationAvailable(verificationReference: VerificationReference): Boolean = {
+    isVerificationAvailable(verificationReference.verificationName)
+  }
+
   def findVerification(verificationName: String): Option[Verification]
+
+  def findVerification(verificationReference: VerificationReference): Option[Verification] = {
+    findVerification(verificationReference.verificationName)
+  }
 }
 
 case class ReferenceContext(

--- a/src/main/scala/definiti/core/parser/ProjectLinking.scala
+++ b/src/main/scala/definiti/core/parser/ProjectLinking.scala
@@ -71,14 +71,14 @@ private[core] object ProjectLinking {
         aliasType.copy(
           packageName = packageName,
           alias = injectLinksIntoTypeReference(aliasType.alias, typeMapping),
-          inherited = aliasType.inherited.map(getLink(_, typeMapping))
+          inherited = aliasType.inherited.map(injectLinksIntoVerificationReference(_, typeMapping))
         )
       case definedType: DefinedType =>
         definedType.copy(
           packageName = packageName,
           attributes = definedType.attributes.map(injectLinksIntoAttributes(_, typeMapping)),
           verifications = definedType.verifications.map(injectLinksIntoTypeVerification(_, typeMapping)),
-          inherited = definedType.inherited.map(getLink(_, typeMapping))
+          inherited = definedType.inherited.map(injectLinksIntoVerificationReference(_, typeMapping))
         )
       case other => other
     }
@@ -87,7 +87,7 @@ private[core] object ProjectLinking {
   private def injectLinksIntoAttributes(attributeDefinition: AttributeDefinition, typeMapping: TypeMapping): AttributeDefinition = {
     attributeDefinition.copy(
       typeReference = injectLinksIntoTypeReference(attributeDefinition.typeReference, typeMapping),
-      verifications = attributeDefinition.verifications.map(getLink(_, typeMapping))
+      verifications = attributeDefinition.verifications.map(injectLinksIntoVerificationReference(_, typeMapping))
     )
   }
 
@@ -128,6 +128,12 @@ private[core] object ProjectLinking {
     lambdaReference.copy(
       inputTypes = lambdaReference.inputTypes.map(injectLinksIntoTypeReference(_, typeMapping)),
       outputType = injectLinksIntoTypeReference(lambdaReference.outputType, typeMapping)
+    )
+  }
+
+  private def injectLinksIntoVerificationReference(verificationReference: VerificationReference, typeMapping: TypeMapping): VerificationReference = {
+    verificationReference.copy(
+      verificationName = getLink(verificationReference.verificationName, typeMapping)
     )
   }
 

--- a/src/main/scala/definiti/core/utils/CollectionUtils.scala
+++ b/src/main/scala/definiti/core/utils/CollectionUtils.scala
@@ -5,13 +5,21 @@ import scala.collection.mutable.ListBuffer
 
 private[core] object CollectionUtils {
   def scalaSeq[A](list: java.util.List[A]): Seq[A] = {
-    list.asScala.toList
+    if (list != null) {
+      list.asScala.toList
+    } else {
+      Seq.empty
+    }
   }
 
   def scalaSeq[A](stream: java.util.stream.Stream[A]): Seq[A] = {
-    val buffer = ListBuffer[A]()
-    stream.forEach((a) => buffer.append(a))
-    buffer
+    if (stream != null) {
+      val buffer = ListBuffer[A]()
+      stream.forEach((a) => buffer.append(a))
+      buffer
+    } else {
+      Seq.empty
+    }
   }
 
   def javaList[A](seq: Seq[A]): java.util.List[A] = {

--- a/src/main/scala/definiti/core/utils/ParserUtils.scala
+++ b/src/main/scala/definiti/core/utils/ParserUtils.scala
@@ -1,8 +1,8 @@
 package definiti.core.utils
 
 import definiti.core.{ParameterDefinition, Position, Range, TypeReference, Variable}
-import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.tree.TerminalNode
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
 
 private[core] object ParserUtils {
   def extractStringContent(string: String): String = {
@@ -28,10 +28,15 @@ private[core] object ParserUtils {
   }
 
   def getRangeFromContext(context: ParserRuleContext): Range = {
-    Range(
-      Position(context.getStart.getLine, context.getStart.getCharPositionInLine),
-      Position(context.getStop.getLine, context.getStop.getCharPositionInLine)
-    )
+    def position(token: Token): Position = {
+      if (token == null) {
+        Position(0, 0)
+      } else {
+        Position(token.getLine, token.getCharPositionInLine)
+      }
+    }
+
+    Range(position(context.getStart), position(context.getStop))
   }
 
   def getRangeFromTerminalNode(terminalNode: TerminalNode): Range = {

--- a/src/test/scala/definiti/core/generators/ASTGenerator.scala
+++ b/src/test/scala/definiti/core/generators/ASTGenerator.scala
@@ -72,7 +72,7 @@ object ASTGenerator {
     name <- anyIdentifier
     typeReference <- anyTypeReference
     comment <- Gen.option(anyIdentifier)
-    verifications <- Gen.listOf(anyIdentifier)
+    verifications <- Gen.listOf(VerificationGenerator.anyVerificationReference)
     range <- anyRange
   } yield {
     AttributeDefinition(
@@ -87,7 +87,7 @@ object ASTGenerator {
   def referencedAttributeDefinition(implicit context: ReferenceContext): Gen[AttributeDefinition] = for {
     attributeDefinition <- anyAttributeDefinition
     typeReference <- referencedTypeReference
-    verifications <- Gen.listOf(referencedVerificationIdentifier)
+    verifications <- Gen.listOf(VerificationGenerator.anyReferencedVerificationReference)
   } yield {
     attributeDefinition.copy(
       typeReference = typeReference,
@@ -105,10 +105,13 @@ object ASTGenerator {
 
   def attributeDefinitionWithNonReferencedVerification(implicit context: ReferenceContext): Gen[AttributeDefinition] = for {
     attributeDefinition <- anyAttributeDefinition
-    verificationName <- anyIdentifier
+    verificationReference <- VerificationGenerator.anyReferencedVerificationReference
   } yield {
+    val nonReferencedVerificationReference = verificationReference.copy(
+      verificationName = makeNonReferenced(verificationReference.verificationName)
+    )
     attributeDefinition.copy(
-      verifications = attributeDefinition.verifications :+ makeNonReferenced(verificationName)
+      verifications = attributeDefinition.verifications :+ nonReferencedVerificationReference
     )
   }
 

--- a/src/test/scala/definiti/core/generators/Generators.scala
+++ b/src/test/scala/definiti/core/generators/Generators.scala
@@ -8,9 +8,9 @@ object Generators {
     elems <- Gen.listOfN(numElems, gen)
   } yield elems
 
-  def numberAsString: Gen[String] = Gen.oneOf(integerAsString, floatAsString)
+  lazy val numberAsString: Gen[String] = Gen.oneOf(integerAsString, floatAsString)
 
-  def integerAsString: Gen[String] = Gen.nonEmptyListOf(Gen.numChar).map(_.mkString(""))
+  lazy val integerAsString: Gen[String] = Gen.nonEmptyListOf(Gen.numChar).map(_.mkString(""))
 
   def floatAsString: Gen[String] = for {
     integer <- integerAsString
@@ -29,4 +29,10 @@ object Generators {
   def listDecreasingFrequencySize[A](min: Int, max: Int, gen: Gen[A]): Gen[List[A]] = {
    decreasingFrequency(min, max).flatMap(numberOfElements => Gen.listOfN(numberOfElements, gen))
   }
+
+  lazy val anyBooleanText: Gen[String] = Gen.oneOf("true", "false")
+
+  lazy val anyString: Gen[String] = Gen.alphaNumStr
+
+  lazy val anyIdentifier: Gen[String] = Gen.alphaNumStr
 }

--- a/src/test/scala/definiti/core/generators/TypeGenerator.scala
+++ b/src/test/scala/definiti/core/generators/TypeGenerator.scala
@@ -12,7 +12,7 @@ object TypeGenerator {
     genericTypes <- ASTGenerator.listOfGenericTypeDefinition
     attributes <- listOfAttributes
     verifications <- listOfTypeVerifications
-    inherited <- Gen.someOf(context.verifications)
+    inherited <- Gen.listOf(VerificationGenerator.anyVerificationReference)
     comment <- Gen.option(ASTGenerator.anyString)
     range <- ASTGenerator.anyRange
   } yield {
@@ -22,7 +22,7 @@ object TypeGenerator {
       genericTypes,
       attributes,
       verifications,
-      inherited.map(_.canonicalName),
+      inherited,
       comment,
       range
     )
@@ -33,7 +33,7 @@ object TypeGenerator {
     packageName <- ASTGenerator.anyPackageName
     genericTypes <- ASTGenerator.listOfGenericTypeDefinition
     alias <- ASTGenerator.referencedTypeReference
-    inherited <- Gen.someOf(context.verifications)
+    inherited <- Gen.listOf(VerificationGenerator.anyVerificationReference)
     comment <- Gen.option(ASTGenerator.anyString)
     range <- ASTGenerator.anyRange
   } yield {
@@ -42,7 +42,7 @@ object TypeGenerator {
       packageName,
       genericTypes,
       alias,
-      inherited.map(_.canonicalName),
+      inherited,
       comment,
       range
     )
@@ -52,7 +52,7 @@ object TypeGenerator {
     name <- ASTGenerator.anyIdentifier
     typeReference <- ASTGenerator.anyTypeReference
     comment <- Gen.option(ASTGenerator.anyString)
-    verifications <- Gen.listOf(ASTGenerator.anyIdentifier)
+    verifications <- Gen.listOf(VerificationGenerator.anyVerificationReference)
     range <- ASTGenerator.anyRange
   } yield {
     AttributeDefinition(

--- a/src/test/scala/definiti/core/generators/VerificationGenerator.scala
+++ b/src/test/scala/definiti/core/generators/VerificationGenerator.scala
@@ -75,4 +75,28 @@ object VerificationGenerator {
       range = range
     )
   }
+
+  def anyVerificationReference(implicit context: Context): Gen[VerificationReference] = for {
+    verificationName <- ASTGenerator.anyIdentifier
+    message <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    VerificationReference(
+      verificationName = verificationName,
+      message = message,
+      range = range
+    )
+  }
+
+  def anyReferencedVerificationReference(implicit context: ReferenceContext): Gen[VerificationReference] = for {
+    verificationName <- Gen.oneOf(context.verifications).map(_.canonicalName)
+    message <- Gen.option(ASTGenerator.anyString)
+    range <- ASTGenerator.anyRange
+  } yield {
+    VerificationReference(
+      verificationName = verificationName,
+      message = message,
+      range = range
+    )
+  }
 }

--- a/src/test/scala/definiti/core/generators/antlr/AntlrGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/AntlrGenerator.scala
@@ -2,22 +2,22 @@ package definiti.core.generators.antlr
 
 import definiti.core.generators.Generators
 import definiti.core.mock.antlr.{TerminalNodeMock, TokenMock}
-import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.tree.TerminalNode
+import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.scalacheck.Gen
 
 object AntlrGenerator {
   lazy val anyBooleanNode: Gen[TerminalNode] = genNode(anyBooleanToken)
-  lazy val anyBooleanToken: Gen[Token] = genToken(Gen.oneOf("true", "false"))
+  lazy val anyBooleanToken: Gen[Token] = genToken(Generators.anyBooleanText)
 
   lazy val anyNumberNode: Gen[TerminalNode] = genNode(anyNumberToken)
   lazy val anyNumberToken: Gen[Token] = genToken(Generators.numberAsString)
 
   lazy val anyStringNode: Gen[TerminalNode] = genNode(anyStringToken)
-  lazy val anyStringToken: Gen[Token] = genToken(Gen.alphaNumStr.map('"' + _ + '"'))
+  lazy val anyStringToken: Gen[Token] = genToken(Generators.anyString.map('"' + _ + '"'))
 
   lazy val anyIdentifierNode: Gen[TerminalNode] = genNode(anyIdentifierToken)
-  lazy val anyIdentifierToken: Gen[Token] = genToken(Gen.alphaNumStr)
+  lazy val anyIdentifierToken: Gen[Token] = genToken(Generators.anyIdentifier)
 
   lazy val anyBinaryOperatorNode: Gen[TerminalNode] = genNode(anyBinaryOperatorToken)
   lazy val anyBinaryOperatorToken: Gen[Token] = genToken(Gen.oneOf("*", "/", "%", "+", "-", "==", "!=", "<", "<=", ">", ">=", "&&", "||"))
@@ -26,7 +26,7 @@ object AntlrGenerator {
   lazy val anyNotOperatorToken: Gen[Token] = genToken(Gen.const("!"))
 
   lazy val anyDocCommentNode: Gen[TerminalNode] = genNode(anyDocCommentToken)
-  lazy val anyDocCommentToken: Gen[Token] = genToken(Gen.alphaNumStr.map("/**" + _ + "*/"))
+  lazy val anyDocCommentToken: Gen[Token] = genToken(Generators.anyString.map("/**" + _ + "*/"))
 
   def genContext[A <: ParserRuleContext](gen: Gen[A]): Gen[A] = for {
     element <- gen

--- a/src/test/scala/definiti/core/generators/antlr/TypeContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/TypeContextGenerator.scala
@@ -10,7 +10,7 @@ object TypeContextGenerator {
     typeNameToken <- AntlrGenerator.anyIdentifierToken
     identifier <- AntlrGenerator.anyIdentifierNode
     docComment <- Gen.option(AntlrGenerator.anyDocCommentNode)
-    inheritances <- Generators.listOfBoundedSize(0, 3, anyInheritanceContext)
+    verifyingListContext <- Gen.option(VerificationContextGenerator.anyVerifyingListContext)
     genericTypeListContext <- Gen.option(GenericTypesContextGenerators.anyGenericTypeListContext)
     attributeDefinitionContexts <- Generators.listOfBoundedSize(0, 3, anyAttributeDefinitionContext)
     typeVerificationContexts <- Generators.listOfBoundedSize(0, 3, anyTypeVerificationContext)
@@ -19,12 +19,16 @@ object TypeContextGenerator {
       typeNameToken,
       identifier,
       docComment,
-      inheritances,
+      verifyingListContext,
       genericTypeListContext,
       attributeDefinitionContexts,
       typeVerificationContexts
     )
   })
+
+  lazy val definedTypeContextWithVerifyingList: Gen[DefinedTypeContext] = {
+    anyDefinedTypeContext.filter(elt => isVerifyingListDefined(elt.verifyingList()))
+  }
 
   lazy val anyAliasTypeContext: Gen[AliasTypeContext] = AntlrGenerator.genContext(for {
     typeNameToken <- AntlrGenerator.anyIdentifierToken
@@ -33,7 +37,7 @@ object TypeContextGenerator {
     aliasGenericTypesContext <- Gen.option(GenericTypesContextGenerators.anyGenericTypeListContext)
     identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
     docComment <- Gen.option(AntlrGenerator.anyDocCommentNode)
-    inheritances <- Generators.listOfBoundedSize(0, 3, anyInheritanceContext)
+    verifyingListContext <- Gen.option(VerificationContextGenerator.anyVerifyingListContext)
   } yield {
     AliasTypeContextMock(
       typeNameToken,
@@ -42,24 +46,18 @@ object TypeContextGenerator {
       aliasGenericTypesContext,
       identifiers,
       docComment,
-      inheritances
+      verifyingListContext
     )
   })
 
-  lazy val anyInheritanceContext: Gen[InheritanceContext] = AntlrGenerator.genContext(for {
-    verificationNameToken <- AntlrGenerator.anyIdentifierToken
-    identifier <- AntlrGenerator.anyIdentifierNode
-  } yield {
-    InheritanceContextMock(
-      verificationNameToken,
-      identifier
-    )
-  })
+  lazy val aliasTypeContextWithVerifyingList: Gen[AliasTypeContext] = {
+    anyAliasTypeContext.filter(elt => isVerifyingListDefined(elt.verifyingList()))
+  }
 
   lazy val anyAttributeDefinitionContext: Gen[AttributeDefinitionContext] = AntlrGenerator.genContext(for {
     attributeNameToken <- AntlrGenerator.anyIdentifierToken
     attributeTypeToken <- AntlrGenerator.anyIdentifierToken
-    attributeVerificationsContext <- anyAttributeVerificationContext
+    verifyingListContext <- Gen.option(VerificationContextGenerator.anyVerifyingListContext)
     identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
     docComment <- Gen.option(AntlrGenerator.anyDocCommentNode)
     genericTypeListContext <- GenericTypesContextGenerators.anyGenericTypeListContext
@@ -67,12 +65,16 @@ object TypeContextGenerator {
     AttributeDefinitionContextMock(
       attributeNameToken,
       attributeTypeToken,
-      attributeVerificationsContext,
+      verifyingListContext,
       identifiers,
       docComment,
       genericTypeListContext
     )
   })
+
+  lazy val attributeDefinitionContextWithVerifyingList: Gen[AttributeDefinitionContext] = {
+    anyAttributeDefinitionContext.filter(elt => isVerifyingListDefined(elt.verifyingList()))
+  }
 
   lazy val anyTypeVerificationContext: Gen[TypeVerificationContext] = AntlrGenerator.genContext(for {
     verificationMessageToken <- AntlrGenerator.anyStringToken
@@ -86,12 +88,6 @@ object TypeContextGenerator {
     )
   })
 
-  lazy val anyAttributeVerificationContext: Gen[AttributeVerificationsContext] = AntlrGenerator.genContext(for {
-    identifiers <- Generators.listOfBoundedSize(0, 3, AntlrGenerator.anyIdentifierNode)
-  } yield {
-    AttributeVerificationsContextMock(identifiers)
-  })
-
   lazy val anyTypeVerificationFunctionContext: Gen[TypeVerificationFunctionContext] = AntlrGenerator.genContext(for {
     identifier <- AntlrGenerator.anyIdentifierNode
     chainedExpressionContext <- ExpressionContextGenerator.anyChainedExpressionContext
@@ -101,4 +97,10 @@ object TypeContextGenerator {
       chainedExpressionContext
     )
   })
+
+  private def isVerifyingListDefined(verifyingListContext: VerifyingListContext): Boolean = {
+    verifyingListContext != null &&
+      verifyingListContext.verifying() != null &&
+      !verifyingListContext.verifying().isEmpty
+  }
 }

--- a/src/test/scala/definiti/core/generators/antlr/VerificationContextGenerator.scala
+++ b/src/test/scala/definiti/core/generators/antlr/VerificationContextGenerator.scala
@@ -1,7 +1,7 @@
 package definiti.core.generators.antlr
 
-import definiti.core.mock.antlr.VerificationContextMock
-import definiti.core.parser.antlr.DefinitiParser.VerificationContext
+import definiti.core.mock.antlr.{VerificationContextMock, VerifyingContextMock, VerifyingListContextMock}
+import definiti.core.parser.antlr.DefinitiParser.{VerificationContext, VerifyingContext, VerifyingListContext}
 import org.scalacheck.Gen
 
 object VerificationContextGenerator {
@@ -20,6 +20,53 @@ object VerificationContextGenerator {
       identifier,
       string,
       docComment
+    )
+  })
+
+  lazy val anyVerifyingListContext: Gen[VerifyingListContext] = AntlrGenerator.genContext(for {
+    verifyingContexts <- Gen.listOf(anyVerifyingContext)
+  } yield {
+    VerifyingListContextMock(verifyingContexts)
+  })
+
+  lazy val verifyingListContextWithMessage: Gen[VerifyingListContext] = AntlrGenerator.genContext(for {
+    verifyingContexts <- Gen.listOf(verifyingContextWithMessage)
+  } yield {
+    VerifyingListContextMock(verifyingContexts)
+  })
+
+  lazy val verifyingListContextWithoutMessage: Gen[VerifyingListContext] = AntlrGenerator.genContext(for {
+    verifyingContexts <- Gen.listOf(verifyingContextWithoutMessage)
+  } yield {
+    VerifyingListContextMock(verifyingContexts)
+  })
+
+  lazy val anyVerifyingContext: Gen[VerifyingContext] = AntlrGenerator.genContext(for {
+    verificationNameToken <- AntlrGenerator.anyIdentifierToken
+    messageToken <- Gen.option(AntlrGenerator.anyStringToken)
+  } yield {
+    VerifyingContextMock(
+      verificationNameToken,
+      messageToken
+    )
+  })
+
+  lazy val verifyingContextWithMessage: Gen[VerifyingContext] = AntlrGenerator.genContext(for {
+    verificationNameToken <- AntlrGenerator.anyIdentifierToken
+    messageToken <- AntlrGenerator.anyStringToken
+  } yield {
+    VerifyingContextMock(
+      verificationNameToken,
+      Some(messageToken)
+    )
+  })
+
+  lazy val verifyingContextWithoutMessage: Gen[VerifyingContext] = AntlrGenerator.genContext(for {
+    verificationNameToken <- AntlrGenerator.anyIdentifierToken
+  } yield {
+    VerifyingContextMock(
+      verificationNameToken,
+      None
     )
   })
 }

--- a/src/test/scala/definiti/core/mock/antlr/AntlrMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/AntlrMock.scala
@@ -1,7 +1,7 @@
 package definiti.core.mock.antlr
 
-import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.{ParseTree, ParseTreeVisitor, TerminalNode}
 
 case class TerminalNodeMock(token: Token) extends TerminalNode {
@@ -53,4 +53,8 @@ case class TokenMock(
   override def getInputStream: CharStream = ???
 
   override def getType: Int = ???
+}
+
+object TokenMock {
+  def apply(text: String) = new TokenMock(text, 0, 0, 0)
 }

--- a/src/test/scala/definiti/core/mock/antlr/TypeContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/TypeContextMock.scala
@@ -14,7 +14,7 @@ case class AliasTypeContextMock(
   aliasGenericTypesContext: Option[GenericTypeListContext],
   identifiers: Seq[TerminalNode],
   docComment: Option[TerminalNode],
-  inheritances: Seq[InheritanceContext]
+  verifyingListContext: Option[VerifyingListContext]
 ) extends AliasTypeContext(null, 0) {
   this.typeName = typeNameToken
   this.genericTypes = genericTypesContext.orNull
@@ -27,20 +27,32 @@ case class AliasTypeContextMock(
 
   override def DOC_COMMENT(): TerminalNode = docComment.orNull
 
-  override def inheritance(): JList[InheritanceContext] = javaList(inheritances)
-
-  override def inheritance(i: Int): InheritanceContext = inheritances(i)
+  override def verifyingList(): VerifyingListContext = verifyingListContext.orNull
 
   override def genericTypeList(): JList[GenericTypeListContext] = javaList(Seq(genericTypes, aliasGenericTypes))
 
   override def genericTypeList(i: Int): GenericTypeListContext = genericTypeList().get(i)
 }
 
+object AliasTypeContextMock {
+  def apply(aliasTypeContext: AliasTypeContext): AliasTypeContextMock = {
+    new AliasTypeContextMock(
+      typeNameToken = aliasTypeContext.typeName,
+      genericTypesContext = Option(aliasTypeContext.genericTypes),
+      referenceTypeNameToken = aliasTypeContext.referenceTypeName,
+      aliasGenericTypesContext = Option(aliasTypeContext.aliasGenericTypes),
+      identifiers = scalaSeq(aliasTypeContext.IDENTIFIER()),
+      docComment = Option(aliasTypeContext.DOC_COMMENT()),
+      verifyingListContext = Option(aliasTypeContext.verifyingList())
+    )
+  }
+}
+
 case class DefinedTypeContextMock(
   typeNameToken: Token,
   identifier: TerminalNode,
   docComment: Option[TerminalNode],
-  inheritances: Seq[InheritanceContext],
+  verifyingListContext: Option[VerifyingListContext],
   genericTypeListContext: Option[GenericTypeListContext],
   attributeDefinitionContexts: Seq[AttributeDefinitionContext],
   typeVerificationContexts: Seq[TypeVerificationContext]
@@ -51,9 +63,7 @@ case class DefinedTypeContextMock(
 
   override def DOC_COMMENT(): TerminalNode = docComment.orNull
 
-  override def inheritance(): JList[InheritanceContext] = javaList(inheritances)
-
-  override def inheritance(i: Int): InheritanceContext = inheritances(i)
+  override def verifyingList(): VerifyingListContext = verifyingListContext.orNull
 
   override def genericTypeList(): GenericTypeListContext = genericTypeListContext.orNull
 
@@ -66,19 +76,24 @@ case class DefinedTypeContextMock(
   override def typeVerification(i: Int): TypeVerificationContext = typeVerificationContexts(i)
 }
 
-case class InheritanceContextMock(
-  verificationNameToken: Token,
-  identifier: TerminalNode
-) extends InheritanceContext(null, 0) {
-  this.verificationName = verificationNameToken
-
-  override def IDENTIFIER(): TerminalNode = identifier
+object DefinedTypeContextMock {
+  def apply(definedTypeContext: DefinedTypeContext): DefinedTypeContextMock = {
+    new DefinedTypeContextMock(
+      typeNameToken = definedTypeContext.typeName,
+      identifier = definedTypeContext.IDENTIFIER(),
+      docComment = Option(definedTypeContext.DOC_COMMENT()),
+      verifyingListContext = Option(definedTypeContext.verifyingList()),
+      genericTypeListContext = Option(definedTypeContext.genericTypeList()),
+      attributeDefinitionContexts = scalaSeq(definedTypeContext.attributeDefinition()),
+      typeVerificationContexts = scalaSeq(definedTypeContext.typeVerification())
+    )
+  }
 }
 
 case class AttributeDefinitionContextMock(
   attributeNameToken: Token,
   attributeTypeToken: Token,
-  attributeVerificationsContext: AttributeVerificationsContext,
+  verifyingListContext: Option[VerifyingListContext],
   identifiers: Seq[TerminalNode],
   docComment: Option[TerminalNode],
   genericTypeListContext: GenericTypeListContext
@@ -86,7 +101,7 @@ case class AttributeDefinitionContextMock(
   this.attributeName = attributeNameToken
   this.attributeType = attributeTypeToken
 
-  override def attributeVerifications(): AttributeVerificationsContext = attributeVerificationsContext
+  override def verifyingList(): VerifyingListContext = verifyingListContext.orNull
 
   override def IDENTIFIER(): JList[TerminalNode] = javaList(identifiers)
 
@@ -97,12 +112,17 @@ case class AttributeDefinitionContextMock(
   override def genericTypeList(): GenericTypeListContext = genericTypeListContext
 }
 
-case class AttributeVerificationsContextMock(
-  identifiers: Seq[TerminalNode]
-) extends AttributeVerificationsContext(null, 0) {
-  override def IDENTIFIER(): JList[TerminalNode] = javaList(identifiers)
-
-  override def IDENTIFIER(i: Int): TerminalNode = identifiers(i)
+object AttributeDefinitionContextMock {
+  def apply(attributeDefinitionContext: AttributeDefinitionContext): AttributeDefinitionContextMock = {
+    new AttributeDefinitionContextMock(
+      attributeNameToken = attributeDefinitionContext.attributeName,
+      attributeTypeToken = attributeDefinitionContext.attributeType,
+      verifyingListContext = Option(attributeDefinitionContext.verifyingList()),
+      identifiers = scalaSeq(attributeDefinitionContext.IDENTIFIER()),
+      docComment = Option(attributeDefinitionContext.DOC_COMMENT()),
+      genericTypeListContext = attributeDefinitionContext.genericTypeList()
+    )
+  }
 }
 
 case class TypeVerificationContextMock(

--- a/src/test/scala/definiti/core/mock/antlr/VerificationContextMock.scala
+++ b/src/test/scala/definiti/core/mock/antlr/VerificationContextMock.scala
@@ -1,6 +1,9 @@
 package definiti.core.mock.antlr
 
-import definiti.core.parser.antlr.DefinitiParser._
+import java.util
+
+import definiti.core.parser.antlr.DefinitiParser.{VerifyingContext, _}
+import definiti.core.utils.CollectionUtils._
 import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.tree.TerminalNode
 
@@ -23,4 +26,24 @@ case class VerificationContextMock(
   override def STRING(): TerminalNode = string
 
   override def DOC_COMMENT(): TerminalNode = docComment
+}
+
+case class VerifyingListContextMock(
+  verifyingContexts: Seq[VerifyingContext]
+) extends VerifyingListContext(null, 0) {
+  override def verifying(): util.List[VerifyingContext] = javaList(verifyingContexts)
+
+  override def verifying(i: Int): VerifyingContext = verifyingContexts(i)
+}
+
+case class VerifyingContextMock(
+  verificationNameToken: Token,
+  messageToken: Option[Token]
+) extends VerifyingContext(null, 0) {
+  this.verificationName = verificationNameToken
+  this.message = messageToken.orNull
+
+  override def IDENTIFIER(): TerminalNode = TerminalNodeMock(verificationNameToken)
+
+  override def STRING(): TerminalNode = messageToken.map(TerminalNodeMock).orNull
 }

--- a/src/test/scala/definiti/core/parser/DefinitiASTParserProcessAliasTypeSpec.scala
+++ b/src/test/scala/definiti/core/parser/DefinitiASTParserProcessAliasTypeSpec.scala
@@ -1,0 +1,40 @@
+package definiti.core.parser
+
+import definiti.core.generators.Generators
+import definiti.core.generators.antlr.TypeContextGenerator
+import definiti.core.mock.antlr._
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class DefinitiASTParserProcessAliasTypeSpec extends FlatSpec with Matchers with PropertyChecks {
+  "DefinitiASTParser.processAliasType" should "returns an alias type with defined list of verifications" in {
+    val cases = for {
+      aliasTypeContext <- TypeContextGenerator.anyAliasTypeContext
+      numberOfVerifications <- Gen.posNum[Int]
+      verificationNames <- Gen.listOfN(numberOfVerifications, Generators.anyIdentifier)
+      verificationMessages <- Gen.listOfN(numberOfVerifications, Gen.option(Generators.anyString))
+    } yield (aliasTypeContext, verificationNames, verificationMessages)
+
+    forAll(cases) { case (aliasTypeContext, verificationNames, verificationMessages) =>
+      val normalized = AliasTypeContextMock(aliasTypeContext).copy(
+        verifyingListContext = Some(VerifyingListContextMock(
+          verifyingContexts = verificationNames.zip(verificationMessages).map { case (name, message) =>
+            VerifyingContextMock(TokenMock(name), message.map(TokenMock(_)))
+          }
+        ))
+      )
+      val result = DefinitiASTParser.processAliasType(normalized)
+      result.inherited should not be empty
+      result.inherited.map(_.verificationName) should contain allElementsOf verificationNames
+      result.inherited.map(_.message) should contain allElementsOf verificationMessages
+    }
+  }
+
+  it should "returns an alias type with list of verifications if verifyingList is set" in {
+    forAll(TypeContextGenerator.aliasTypeContextWithVerifyingList) { attributeDefinitionContext =>
+      val result = DefinitiASTParser.processAliasType(attributeDefinitionContext)
+      result.inherited should not be empty
+    }
+  }
+}

--- a/src/test/scala/definiti/core/parser/DefinitiASTParserProcessAttributeDefinitionSpec.scala
+++ b/src/test/scala/definiti/core/parser/DefinitiASTParserProcessAttributeDefinitionSpec.scala
@@ -1,0 +1,40 @@
+package definiti.core.parser
+
+import definiti.core.generators.Generators
+import definiti.core.generators.antlr.TypeContextGenerator
+import definiti.core.mock.antlr.{AttributeDefinitionContextMock, TokenMock, VerifyingContextMock, VerifyingListContextMock}
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class DefinitiASTParserProcessAttributeDefinitionSpec extends FlatSpec with Matchers with PropertyChecks {
+  "DefinitiASTParser.processAttributeDefinition" should "returns an attribute definition with defined list of verifications" in {
+    val cases = for {
+      attributeDefinitionContext <- TypeContextGenerator.anyAttributeDefinitionContext
+      numberOfVerifications <- Gen.posNum[Int]
+      verificationNames <- Gen.listOfN(numberOfVerifications, Generators.anyIdentifier)
+      verificationMessages <- Gen.listOfN(numberOfVerifications, Gen.option(Generators.anyString))
+    } yield (attributeDefinitionContext, verificationNames, verificationMessages)
+
+    forAll(cases) { case (attributeDefinitionContext, verificationNames, verificationMessages) =>
+      val normalized = AttributeDefinitionContextMock(attributeDefinitionContext).copy(
+        verifyingListContext = Some(VerifyingListContextMock(
+          verifyingContexts = verificationNames.zip(verificationMessages).map { case (name, message) =>
+            VerifyingContextMock(TokenMock(name), message.map(TokenMock(_)))
+          }
+        ))
+      )
+      val result = DefinitiASTParser.processAttributeDefinition(normalized)
+      result.verifications should not be empty
+      result.verifications.map(_.verificationName) should contain allElementsOf verificationNames
+      result.verifications.map(_.message) should contain allElementsOf verificationMessages
+    }
+  }
+
+  it should "returns an attribute definition with list of verifications if verifyingList is set" in {
+    forAll(TypeContextGenerator.attributeDefinitionContextWithVerifyingList) { attributeDefinitionContext =>
+      val result = DefinitiASTParser.processAttributeDefinition(attributeDefinitionContext)
+      result.verifications should not be empty
+    }
+  }
+}

--- a/src/test/scala/definiti/core/parser/DefinitiASTParserProcessDefinedTypeSpec.scala
+++ b/src/test/scala/definiti/core/parser/DefinitiASTParserProcessDefinedTypeSpec.scala
@@ -1,7 +1,10 @@
 package definiti.core.parser
 
-import definiti.core.generators.antlr.TypeContextGenerator
 import definiti.core.TypeReference
+import definiti.core.generators.Generators
+import definiti.core.generators.antlr.TypeContextGenerator
+import definiti.core.mock.antlr._
+import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
@@ -15,6 +18,48 @@ class DefinitiASTParserProcessDefinedTypeSpec extends FlatSpec with Matchers wit
         verification.function.parameters.head.typeReference should be(a[TypeReference])
         verification.function.parameters.head.typeReference.asInstanceOf[TypeReference].typeName should be(result.name)
       }
+    }
+  }
+
+  it should "return a type definition with defined list of verifications" in {
+    forAll(TypeContextGenerator.anyDefinedTypeContext) { definedTypeContext =>
+      val result = DefinitiASTParser.processDefinedType(definedTypeContext)
+
+      Inspectors.forAll(result.verifications.toList) { verification =>
+        verification.function.parameters should have length 1
+        verification.function.parameters.head.typeReference should be(a[TypeReference])
+        verification.function.parameters.head.typeReference.asInstanceOf[TypeReference].typeName should be(result.name)
+      }
+    }
+  }
+
+  it should "returns a type definition with defined list of verifications" in {
+    val cases = for {
+      definedTypeContext <- TypeContextGenerator.anyDefinedTypeContext
+      numberOfVerifications <- Gen.posNum[Int]
+      verificationNames <- Gen.listOfN(numberOfVerifications, Generators.anyIdentifier)
+      verificationMessages <- Gen.listOfN(numberOfVerifications, Gen.option(Generators.anyString))
+    } yield (definedTypeContext, verificationNames, verificationMessages)
+
+    forAll(cases) { case (definedTypeContext, verificationNames, verificationMessages) =>
+      val normalized = DefinedTypeContextMock(definedTypeContext).copy(
+        verifyingListContext = Some(VerifyingListContextMock(
+          verifyingContexts = verificationNames.zip(verificationMessages).map { case (name, message) =>
+            VerifyingContextMock(TokenMock(name), message.map(TokenMock(_)))
+          }
+        ))
+      )
+      val result = DefinitiASTParser.processDefinedType(normalized)
+      result.inherited should not be empty
+      result.inherited.map(_.verificationName) should contain allElementsOf verificationNames
+      result.inherited.map(_.message) should contain allElementsOf verificationMessages
+    }
+  }
+
+  it should "returns a type definition with list of verifications if verifyingList is set" in {
+    forAll(TypeContextGenerator.definedTypeContextWithVerifyingList) { attributeDefinitionContext =>
+      val result = DefinitiASTParser.processDefinedType(attributeDefinitionContext)
+      result.inherited should not be empty
     }
   }
 }

--- a/src/test/scala/definiti/core/parser/DefinitiASTParserProcessVerifyingListSpec.scala
+++ b/src/test/scala/definiti/core/parser/DefinitiASTParserProcessVerifyingListSpec.scala
@@ -1,0 +1,27 @@
+package definiti.core.parser
+
+import definiti.core.generators.antlr.VerificationContextGenerator
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
+
+class DefinitiASTParserProcessVerifyingListSpec extends FlatSpec with Matchers with PropertyChecks {
+  "DefinitiASTParser.processVerifyingList" should "return VerificationReference without message when not set" in {
+    forAll(VerificationContextGenerator.verifyingListContextWithoutMessage) { verifyingListContext =>
+      val result = DefinitiASTParser.processVerifyingList(verifyingListContext)
+
+      Inspectors.forAll(result.toList) { verificationReference =>
+        verificationReference.message should be(empty)
+      }
+    }
+  }
+
+  "DefinitiASTParser.processVerifyingList" should "return VerificationReference with message when set" in {
+    forAll(VerificationContextGenerator.verifyingListContextWithMessage) { verifyingListContext =>
+      val result = DefinitiASTParser.processVerifyingList(verifyingListContext)
+
+      Inspectors.forAll(result.toList) { verificationReference =>
+        verificationReference.message should be(defined)
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Change definiti file by adding `verifyingList` definition
* Create AST type `VerificationReference`
* Update parser to use the new definition and AST type
* Update `Context` to consider the new type instead of only-string verification
* Update generators to include the new type
* Add tests considering the new AST type
* Update sample
* This commit resolves #11